### PR TITLE
fix compare error when datagram too large

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -349,7 +349,8 @@ func (c *Conn) WritePacket(b []byte) (icmp []byte, err error) {
 		return nil, nil
 	}
 	if err := c.str.SendDatagram(data); err != nil {
-		if errors.Is(err, &quic.DatagramTooLargeError{}) {
+		var dgramTooLargeErr *quic.DatagramTooLargeError
+		if errors.As(err, &dgramTooLargeErr) {
 			icmpPacket, err := composeICMPTooLargePacket(b, minMTU)
 			if err != nil {
 				log.Printf("failed to compose ICMP too large packet: %s", err)


### PR DESCRIPTION
This PR replaces errors.Is(err, &quic.DatagramTooLargeError{}) with errors.As(err, &dgramTooLargeErr), ensuring proper type checking and error handling.