### PR TITLE
work around Docker’s non-deterministic network interface assignment

### DIFF
--- a/integration/proxy/run.sh
+++ b/integration/proxy/run.sh
@@ -2,6 +2,28 @@
 
 set -e
 
+# The proxy is set up with two Docker networks.
+# This creates two network interfaces, eth0 and eth1.
+# However, the setup is not deterministic:
+# We don't know which interface will be assigned to which network.
+# We therefore swap eth0 and eth1 such that eth0 is the interface facing the client,
+# and eth1 is the interface facing the server.
+if [ "$(ip addr show eth1 | grep 'inet ' | awk '{print $2}' | cut -d/ -f1)" = "$SERVER_NET_IPV4" ]; then
+  echo "swapping eth0 and eth1"
+  ip link set eth0 down
+  ip link set eth1 down
+  ip link set eth0 name eth_temp
+  ip link set eth1 name eth0
+  ip link set eth_temp name eth1
+  ip link set eth0 up
+  ip link set eth1 up
+fi
+
+echo "eth0:"
+ip addr show eth0
+echo "eth1:"
+ip addr show eth1
+
 ethtool -K eth0 tx off
 ethtool -K eth1 tx off
 


### PR DESCRIPTION
The proxy is set up with two Docker networks. This creates two network interfaces, eth0 and eth1, in the proxy container. However, the setup is not deterministic: We don't know which interface will be assigned to which network.

To restore determinisim, we therefore switch the names of eth0 and eth1 around such the eth0 is the interface facing the client, and eth1 the interface facing the server.