### PR TITLE
skip unknown capsules

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -231,7 +231,9 @@ func (c *Conn) readFromStream() error {
 			default:
 			}
 		default:
-			return fmt.Errorf("unknown capsule type: %d", t)
+			if _, err := io.Copy(io.Discard, cr); err != nil {
+				return err
+			}
 		}
 	}
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/net/ipv6"
 
 	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/quicvarint"
 
 	"github.com/stretchr/testify/require"
 )
@@ -202,6 +203,25 @@ func TestIncomingDatagrams(t *testing.T) {
 		// after processing the address assignment, this is a valid packet
 		require.NoError(t, conn.handleIncomingProxiedPacket(data))
 	})
+}
+
+func TestSkipUnknownCapsule(t *testing.T) {
+	readChan := make(chan []byte, 1)
+	conn := newProxiedConn(&mockStream{toRead: readChan})
+
+	data := quicvarint.Append(nil, 42)
+	data = quicvarint.Append(data, 3)
+	data = append(data, "foo"...)
+	data = (&addressAssignCapsule{
+		AssignedAddresses: []AssignedAddress{{IPPrefix: netip.MustParsePrefix("192.168.0.10/32")}},
+	}).append(data)
+	readChan <- data
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	prefixes, err := conn.LocalPrefixes(ctx)
+	require.NoError(t, err)
+	require.Equal(t, []netip.Prefix{netip.MustParsePrefix("192.168.0.10/32")}, prefixes)
 }
 
 func FuzzIncomingDatagram(f *testing.F) {


### PR DESCRIPTION
RFC 9297 Section 3.2 says that unknown capsule types need to be skipped.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip unknown capsule types in `Conn.readFromStream`
> Previously, encountering an unknown capsule type caused `readFromStream` to return an error, halting processing of the stream. Now, the default case in the capsule switch drains the unknown capsule's contents to `io.Discard` and continues reading subsequent capsules. A test covering an unknown capsule followed by a known `addressAssign` capsule is added in [conn_test.go](https://github.com/quic-go/connect-ip-go/pull/54/files#diff-e23b4ab1f834694782fc82e170f513556a61155002e760c071fd1184407455ab).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5139985.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection reliability by safely ignoring unrecognized capsule types and continuing to process supported data.
  * Address assignments now succeed even when unknown capsule types appear beforehand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->