### PR TITLE
ci: define permissions for all workflows

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,5 +1,8 @@
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   unit:
     strategy:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,5 +1,8 @@
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   unit:
     strategy:


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Restrict `GITHUB_TOKEN` permissions to `contents: read` across all CI workflows
Adds a top-level `permissions: contents: read` block to the [integration](https://github.com/quic-go/connect-ip-go/pull/60/files#diff-82454b2fc887e9985b9348b8f3bca03d2f839645a4c3ba1f3f850014d7da5c8b), [lint](https://github.com/quic-go/connect-ip-go/pull/60/files#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2), and [unit](https://github.com/quic-go/connect-ip-go/pull/60/files#diff-e17ac7ab478a18e9dac875e191cc3e0d754fab62eddddfb05d4619495be927d9) workflows, following the principle of least privilege for CI tokens.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized c04d231.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflows to use explicit read-only repository content permissions.
  * Workflow triggers, jobs, steps, and runner behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->