### PR TITLE
add support for the DNS and PREF64 Configuration extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ connect-ip-go is an implementation of the CONNECT-IP protocol [RFC 9484](https:/
 
 It is based on [quic-go](https://github.com/quic-go/quic-go), and provides both a client and a proxy implementation.
 
+It also implements [draft-ietf-masque-connect-ip-dns-06](https://datatracker.ietf.org/doc/html/draft-ietf-masque-connect-ip-dns-06), which adds DNS and PREF64 configuration to CONNECT-IP.
+
 At this point, it supports the following use cases:
 * Remote Access VPN, see [Section 8.1 of RFC 9484](https://datatracker.ietf.org/doc/html/rfc9484#section-8.1)
 * Site-to-Site VPN, see [Section 8.2 of RFC 9484](https://datatracker.ietf.org/doc/html/rfc9484#section-8.2)

--- a/capsule.go
+++ b/capsule.go
@@ -480,9 +480,6 @@ func parsePREF64Capsule(r http3.CapsuleReader) (*pref64Capsule, error) {
 		if prefix.Addr().Is4In6() {
 			return nil, errors.New("IPv4-mapped IPv6 addresses are not valid NAT64 prefixes")
 		}
-		if prefix != prefix.Masked() {
-			return nil, errors.New("lower bits not covered by NAT64 prefix length are not all zero")
-		}
 		prefixes = append(prefixes, prefix)
 	}
 	return &pref64Capsule{Prefixes: prefixes}, nil

--- a/capsule.go
+++ b/capsule.go
@@ -317,10 +317,11 @@ func parseDNSAssignCapsule(r http3.CapsuleReader) (*dnsAssignCapsule, error) {
 }
 
 func parseDNSNameserver(r quicvarint.Reader) (DNSNameserver, error) {
-	var priority uint16
-	if err := binary.Read(r, binary.BigEndian, &priority); err != nil {
+	var priorityBytes [2]byte
+	if _, err := io.ReadFull(r, priorityBytes[:]); err != nil {
 		return DNSNameserver{}, err
 	}
+	priority := binary.BigEndian.Uint16(priorityBytes[:])
 	if priority == 0 {
 		return DNSNameserver{}, errors.New("service priority must not be zero")
 	}

--- a/capsule.go
+++ b/capsule.go
@@ -450,11 +450,18 @@ type pref64Capsule struct {
 	Prefixes []netip.Prefix
 }
 
+const maxPREF64Prefixes = 64
+
 func parsePREF64Capsule(r http3.CapsuleReader) (*pref64Capsule, error) {
+	// each prefix consists of a 1-byte prefix length and 12 bytes of address
 	if r.Remaining()%13 != 0 {
 		return nil, errors.New("PREF64 capsule length is not a multiple of 13")
 	}
-	var prefixes []netip.Prefix
+	numPrefixes := r.Remaining() / 13
+	if numPrefixes > maxPREF64Prefixes {
+		return nil, fmt.Errorf("PREF64 capsule contains too many prefixes: %d (maximum %d)", numPrefixes, maxPREF64Prefixes)
+	}
+	prefixes := make([]netip.Prefix, 0, numPrefixes)
 	for r.Remaining() > 0 {
 		prefixLen, err := r.ReadByte()
 		if err != nil {

--- a/capsule.go
+++ b/capsule.go
@@ -450,7 +450,7 @@ type pref64Capsule struct {
 	Prefixes []netip.Prefix
 }
 
-const maxPREF64Prefixes = 64
+const maxPREF64Prefixes = 256
 
 func parsePREF64Capsule(r http3.CapsuleReader) (*pref64Capsule, error) {
 	// each prefix consists of a 1-byte prefix length and 12 bytes of address

--- a/capsule.go
+++ b/capsule.go
@@ -293,7 +293,7 @@ func parseCounted[T any](r quicvarint.Reader, parse func(quicvarint.Reader) (T, 
 }
 
 func parseDNSAssignCapsule(r http3.CapsuleReader) (*dnsAssignCapsule, error) {
-	capsule := &dnsAssignCapsule{}
+	var configurations []DNSConfiguration
 	for r.Remaining() > 0 {
 		nameservers, err := parseCounted(r, parseDNSNameserver)
 		if err != nil {
@@ -307,13 +307,14 @@ func parseDNSAssignCapsule(r http3.CapsuleReader) (*dnsAssignCapsule, error) {
 		if err != nil {
 			return nil, err
 		}
-		capsule.DNSConfigurations = append(capsule.DNSConfigurations, DNSConfiguration{
+		configuration := DNSConfiguration{
 			Nameservers:     nameservers,
 			InternalDomains: internalDomains,
 			SearchDomains:   searchDomains,
-		})
+		}
+		configurations = append(configurations, configuration)
 	}
-	return capsule, nil
+	return &dnsAssignCapsule{DNSConfigurations: configurations}, nil
 }
 
 func parseDNSNameserver(r quicvarint.Reader) (DNSNameserver, error) {
@@ -321,36 +322,37 @@ func parseDNSNameserver(r quicvarint.Reader) (DNSNameserver, error) {
 	if _, err := io.ReadFull(r, priorityBytes[:]); err != nil {
 		return DNSNameserver{}, err
 	}
-	priority := binary.BigEndian.Uint16(priorityBytes[:])
-	if priority == 0 {
+	servicePriority := binary.BigEndian.Uint16(priorityBytes[:])
+	if servicePriority == 0 {
 		return DNSNameserver{}, errors.New("service priority must not be zero")
 	}
-	nameserver := DNSNameserver{ServicePriority: priority}
 	ipv4Count, err := quicvarint.Read(r)
 	if err != nil {
 		return DNSNameserver{}, err
 	}
+	var ipv4Addresses []netip.Addr
 	for range ipv4Count {
 		var addr [4]byte
 		if _, err := io.ReadFull(r, addr[:]); err != nil {
 			return DNSNameserver{}, err
 		}
-		nameserver.IPv4Addresses = append(nameserver.IPv4Addresses, netip.AddrFrom4(addr))
+		ipv4Addresses = append(ipv4Addresses, netip.AddrFrom4(addr))
 	}
 
 	ipv6Count, err := quicvarint.Read(r)
 	if err != nil {
 		return DNSNameserver{}, err
 	}
+	var ipv6Addresses []netip.Addr
 	for range ipv6Count {
 		var addr [16]byte
 		if _, err := io.ReadFull(r, addr[:]); err != nil {
 			return DNSNameserver{}, err
 		}
-		nameserver.IPv6Addresses = append(nameserver.IPv6Addresses, netip.AddrFrom16(addr))
+		ipv6Addresses = append(ipv6Addresses, netip.AddrFrom16(addr))
 	}
 
-	nameserver.AuthenticationDomainName, err = parseDomain(r)
+	authenticationDomainName, err := parseDomain(r)
 	if err != nil {
 		return DNSNameserver{}, err
 	}
@@ -361,13 +363,20 @@ func parseDNSNameserver(r quicvarint.Reader) (DNSNameserver, error) {
 	if paramsLen > maxServiceParametersLen {
 		return DNSNameserver{}, fmt.Errorf("service parameters too long: %d bytes", paramsLen)
 	}
+	var serviceParameters []byte
 	if paramsLen > 0 {
-		nameserver.ServiceParameters = make([]byte, int(paramsLen))
-		if _, err := io.ReadFull(r, nameserver.ServiceParameters); err != nil {
+		serviceParameters = make([]byte, int(paramsLen))
+		if _, err := io.ReadFull(r, serviceParameters); err != nil {
 			return DNSNameserver{}, err
 		}
 	}
-	return nameserver, nil
+	return DNSNameserver{
+		ServicePriority:          servicePriority,
+		IPv4Addresses:            ipv4Addresses,
+		IPv6Addresses:            ipv6Addresses,
+		AuthenticationDomainName: authenticationDomainName,
+		ServiceParameters:        serviceParameters,
+	}, nil
 }
 
 func parseDomain(r quicvarint.Reader) (string, error) {
@@ -435,7 +444,7 @@ func parsePREF64Capsule(r http3.CapsuleReader) (*pref64Capsule, error) {
 	if r.Remaining()%13 != 0 {
 		return nil, errors.New("PREF64 capsule length is not a multiple of 13")
 	}
-	capsule := &pref64Capsule{}
+	var prefixes []netip.Prefix
 	for r.Remaining() > 0 {
 		prefixLen, err := r.ReadByte()
 		if err != nil {
@@ -454,9 +463,9 @@ func parsePREF64Capsule(r http3.CapsuleReader) (*pref64Capsule, error) {
 		if prefix != prefix.Masked() {
 			return nil, errors.New("lower bits not covered by NAT64 prefix length are not all zero")
 		}
-		capsule.Prefixes = append(capsule.Prefixes, prefix)
+		prefixes = append(prefixes, prefix)
 	}
-	return capsule, nil
+	return &pref64Capsule{Prefixes: prefixes}, nil
 }
 
 func (c *pref64Capsule) append(b []byte) []byte {

--- a/capsule.go
+++ b/capsule.go
@@ -276,7 +276,11 @@ type dnsAssignCapsule struct {
 	DNSConfigurations []DNSConfiguration
 }
 
-func parseCounted[T any](r quicvarint.Reader, parse func(quicvarint.Reader) (T, error)) ([]T, error) {
+// This limits the wire size, not memory use. Parsing can amplify memory use by
+// roughly 50x, and the limit is chosen accordingly.
+const maxDNSAssignCapsuleSize = 32 << 10
+
+func parseCounted[T any](r http3.CapsuleReader, parse func(http3.CapsuleReader) (T, error)) ([]T, error) {
 	count, err := quicvarint.Read(r)
 	if err != nil {
 		return nil, err
@@ -293,6 +297,9 @@ func parseCounted[T any](r quicvarint.Reader, parse func(quicvarint.Reader) (T, 
 }
 
 func parseDNSAssignCapsule(r http3.CapsuleReader) (*dnsAssignCapsule, error) {
+	if r.Remaining() > maxDNSAssignCapsuleSize {
+		return nil, fmt.Errorf("DNS_ASSIGN capsule too large: %d bytes (maximum %d)", r.Remaining(), maxDNSAssignCapsuleSize)
+	}
 	var configurations []DNSConfiguration
 	for r.Remaining() > 0 {
 		nameservers, err := parseCounted(r, parseDNSNameserver)
@@ -320,7 +327,7 @@ func parseDNSAssignCapsule(r http3.CapsuleReader) (*dnsAssignCapsule, error) {
 	return &dnsAssignCapsule{DNSConfigurations: configurations}, nil
 }
 
-func parseDNSNameserver(r quicvarint.Reader) (DNSNameserver, error) {
+func parseDNSNameserver(r http3.CapsuleReader) (DNSNameserver, error) {
 	var priorityBytes [2]byte
 	if _, err := io.ReadFull(r, priorityBytes[:]); err != nil {
 		return DNSNameserver{}, err
@@ -363,6 +370,9 @@ func parseDNSNameserver(r quicvarint.Reader) (DNSNameserver, error) {
 	if paramsLen > maxServiceParametersLen {
 		return DNSNameserver{}, fmt.Errorf("service parameters too long: %d bytes", paramsLen)
 	}
+	if paramsLen > uint64(r.Remaining()) {
+		return DNSNameserver{}, io.ErrUnexpectedEOF
+	}
 	var serviceParameters []byte
 	if paramsLen > 0 {
 		serviceParameters = make([]byte, int(paramsLen))
@@ -379,7 +389,7 @@ func parseDNSNameserver(r quicvarint.Reader) (DNSNameserver, error) {
 	}, nil
 }
 
-func parseDomain(r quicvarint.Reader) (string, error) {
+func parseDomain(r http3.CapsuleReader) (string, error) {
 	l, err := quicvarint.Read(r)
 	if err != nil {
 		return "", err

--- a/capsule.go
+++ b/capsule.go
@@ -477,6 +477,9 @@ func parsePREF64Capsule(r http3.CapsuleReader) (*pref64Capsule, error) {
 			return nil, err
 		}
 		prefix := netip.PrefixFrom(netip.AddrFrom16(addrBytes), int(prefixLen))
+		if prefix.Addr().Is4In6() {
+			return nil, errors.New("IPv4-mapped IPv6 addresses are not valid NAT64 prefixes")
+		}
 		if prefix != prefix.Masked() {
 			return nil, errors.New("lower bits not covered by NAT64 prefix length are not all zero")
 		}

--- a/capsule.go
+++ b/capsule.go
@@ -312,6 +312,9 @@ func parseDNSAssignCapsule(r http3.CapsuleReader) (*dnsAssignCapsule, error) {
 			InternalDomains: internalDomains,
 			SearchDomains:   searchDomains,
 		}
+		if err := configuration.validate(); err != nil {
+			return nil, fmt.Errorf("invalid DNS configuration: %w", err)
+		}
 		configurations = append(configurations, configuration)
 	}
 	return &dnsAssignCapsule{DNSConfigurations: configurations}, nil
@@ -323,9 +326,6 @@ func parseDNSNameserver(r quicvarint.Reader) (DNSNameserver, error) {
 		return DNSNameserver{}, err
 	}
 	servicePriority := binary.BigEndian.Uint16(priorityBytes[:])
-	if servicePriority == 0 {
-		return DNSNameserver{}, errors.New("service priority must not be zero")
-	}
 	ipv4Count, err := quicvarint.Read(r)
 	if err != nil {
 		return DNSNameserver{}, err

--- a/capsule.go
+++ b/capsule.go
@@ -15,6 +15,9 @@ const (
 	capsuleTypeAddressAssign      http3.CapsuleType = 1
 	capsuleTypeAddressRequest     http3.CapsuleType = 2
 	capsuleTypeRouteAdvertisement http3.CapsuleType = 3
+	// draft-ietf-masque-connect-ip-dns-06
+	capsuleTypeDNSAssign http3.CapsuleType = 0x1ace79ec
+	capsuleTypePREF64    http3.CapsuleType = 0x274c0fbc
 )
 
 // addressAssignCapsule represents an ADDRESS_ASSIGN capsule
@@ -265,4 +268,203 @@ func parseIPAddressRange(r io.Reader) (IPRoute, error) {
 		EndIP:      endIP,
 		IPProtocol: ipProtocol,
 	}, nil
+}
+
+// dnsAssignCapsule represents a DNS_ASSIGN capsule defined by
+// draft-ietf-masque-connect-ip-dns-06.
+type dnsAssignCapsule struct {
+	DNSConfigurations []DNSConfiguration
+}
+
+func parseCounted[T any](r quicvarint.Reader, parse func(quicvarint.Reader) (T, error)) ([]T, error) {
+	count, err := quicvarint.Read(r)
+	if err != nil {
+		return nil, err
+	}
+	var values []T
+	for range count {
+		value, err := parse(r)
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, value)
+	}
+	return values, nil
+}
+
+func parseDNSAssignCapsule(r http3.CapsuleReader) (*dnsAssignCapsule, error) {
+	capsule := &dnsAssignCapsule{}
+	for r.Remaining() > 0 {
+		nameservers, err := parseCounted(r, parseDNSNameserver)
+		if err != nil {
+			return nil, err
+		}
+		internalDomains, err := parseCounted(r, parseDomain)
+		if err != nil {
+			return nil, err
+		}
+		searchDomains, err := parseCounted(r, parseDomain)
+		if err != nil {
+			return nil, err
+		}
+		capsule.DNSConfigurations = append(capsule.DNSConfigurations, DNSConfiguration{
+			Nameservers:     nameservers,
+			InternalDomains: internalDomains,
+			SearchDomains:   searchDomains,
+		})
+	}
+	return capsule, nil
+}
+
+func parseDNSNameserver(r quicvarint.Reader) (DNSNameserver, error) {
+	var priority uint16
+	if err := binary.Read(r, binary.BigEndian, &priority); err != nil {
+		return DNSNameserver{}, err
+	}
+	if priority == 0 {
+		return DNSNameserver{}, errors.New("service priority must not be zero")
+	}
+	nameserver := DNSNameserver{ServicePriority: priority}
+	ipv4Count, err := quicvarint.Read(r)
+	if err != nil {
+		return DNSNameserver{}, err
+	}
+	for range ipv4Count {
+		var addr [4]byte
+		if _, err := io.ReadFull(r, addr[:]); err != nil {
+			return DNSNameserver{}, err
+		}
+		nameserver.IPv4Addresses = append(nameserver.IPv4Addresses, netip.AddrFrom4(addr))
+	}
+
+	ipv6Count, err := quicvarint.Read(r)
+	if err != nil {
+		return DNSNameserver{}, err
+	}
+	for range ipv6Count {
+		var addr [16]byte
+		if _, err := io.ReadFull(r, addr[:]); err != nil {
+			return DNSNameserver{}, err
+		}
+		nameserver.IPv6Addresses = append(nameserver.IPv6Addresses, netip.AddrFrom16(addr))
+	}
+
+	nameserver.AuthenticationDomainName, err = parseDomain(r)
+	if err != nil {
+		return DNSNameserver{}, err
+	}
+	paramsLen, err := quicvarint.Read(r)
+	if err != nil {
+		return DNSNameserver{}, err
+	}
+	if paramsLen > maxServiceParametersLen {
+		return DNSNameserver{}, fmt.Errorf("service parameters too long: %d bytes", paramsLen)
+	}
+	if paramsLen > 0 {
+		nameserver.ServiceParameters = make([]byte, int(paramsLen))
+		if _, err := io.ReadFull(r, nameserver.ServiceParameters); err != nil {
+			return DNSNameserver{}, err
+		}
+	}
+	return nameserver, nil
+}
+
+func parseDomain(r quicvarint.Reader) (string, error) {
+	l, err := quicvarint.Read(r)
+	if err != nil {
+		return "", err
+	}
+	if l > maxDomainNameLen {
+		return "", fmt.Errorf("domain name too long: %d bytes", l)
+	}
+	if l == 0 {
+		return "", nil
+	}
+	b := make([]byte, int(l))
+	if _, err := io.ReadFull(r, b); err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func (c *dnsAssignCapsule) append(b []byte) []byte {
+	payload := make([]byte, 0, 256)
+	for _, cfg := range c.DNSConfigurations {
+		payload = quicvarint.Append(payload, uint64(len(cfg.Nameservers)))
+		for _, nameserver := range cfg.Nameservers {
+			payload = binary.BigEndian.AppendUint16(payload, nameserver.ServicePriority)
+			payload = quicvarint.Append(payload, uint64(len(nameserver.IPv4Addresses)))
+			for _, addr := range nameserver.IPv4Addresses {
+				payload = append(payload, addr.AsSlice()...)
+			}
+			payload = quicvarint.Append(payload, uint64(len(nameserver.IPv6Addresses)))
+			for _, addr := range nameserver.IPv6Addresses {
+				payload = append(payload, addr.AsSlice()...)
+			}
+			payload = appendDomain(payload, nameserver.AuthenticationDomainName)
+			payload = quicvarint.Append(payload, uint64(len(nameserver.ServiceParameters)))
+			payload = append(payload, nameserver.ServiceParameters...)
+		}
+		payload = quicvarint.Append(payload, uint64(len(cfg.InternalDomains)))
+		for _, domain := range cfg.InternalDomains {
+			payload = appendDomain(payload, domain)
+		}
+		payload = quicvarint.Append(payload, uint64(len(cfg.SearchDomains)))
+		for _, domain := range cfg.SearchDomains {
+			payload = appendDomain(payload, domain)
+		}
+	}
+	b = quicvarint.Append(b, uint64(capsuleTypeDNSAssign))
+	b = quicvarint.Append(b, uint64(len(payload)))
+	return append(b, payload...)
+}
+
+func appendDomain(b []byte, domain string) []byte {
+	b = quicvarint.Append(b, uint64(len(domain)))
+	return append(b, domain...)
+}
+
+// pref64Capsule represents a PREF64 capsule defined by
+// draft-ietf-masque-connect-ip-dns-06.
+type pref64Capsule struct {
+	Prefixes []netip.Prefix
+}
+
+func parsePREF64Capsule(r http3.CapsuleReader) (*pref64Capsule, error) {
+	if r.Remaining()%13 != 0 {
+		return nil, errors.New("PREF64 capsule length is not a multiple of 13")
+	}
+	capsule := &pref64Capsule{}
+	for r.Remaining() > 0 {
+		prefixLen, err := r.ReadByte()
+		if err != nil {
+			return nil, err
+		}
+		switch prefixLen {
+		case 32, 40, 48, 56, 64, 96:
+		default:
+			return nil, fmt.Errorf("invalid NAT64 prefix length: %d", prefixLen)
+		}
+		var addrBytes [16]byte
+		if _, err := io.ReadFull(r, addrBytes[:12]); err != nil {
+			return nil, err
+		}
+		prefix := netip.PrefixFrom(netip.AddrFrom16(addrBytes), int(prefixLen))
+		if prefix != prefix.Masked() {
+			return nil, errors.New("lower bits not covered by NAT64 prefix length are not all zero")
+		}
+		capsule.Prefixes = append(capsule.Prefixes, prefix)
+	}
+	return capsule, nil
+}
+
+func (c *pref64Capsule) append(b []byte) []byte {
+	b = quicvarint.Append(b, uint64(capsuleTypePREF64))
+	b = quicvarint.Append(b, uint64(13*len(c.Prefixes)))
+	for _, prefix := range c.Prefixes {
+		b = append(b, byte(prefix.Bits()))
+		addr := prefix.Addr().As16()
+		b = append(b, addr[:12]...)
+	}
+	return b
 }

--- a/capsule_test.go
+++ b/capsule_test.go
@@ -25,6 +25,28 @@ func newCapsuleReader(t *testing.T, typ http3.CapsuleType, payload []byte) http3
 	return cr
 }
 
+func testIncompleteCapsule(t *testing.T, data []byte, parse func(http3.CapsuleReader) error) {
+	t.Helper()
+
+	r := bytes.NewReader(data)
+	_, cr, err := http3.NewCapsuleParser(r).Next()
+	require.NoError(t, err)
+	require.NoError(t, parse(cr))
+	require.Zero(t, r.Len())
+	for i := range data {
+		_, cr, err := http3.NewCapsuleParser(bytes.NewReader(data[:i])).Next()
+		if err != nil {
+			if i == 0 {
+				require.ErrorIs(t, err, io.EOF)
+			} else {
+				require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+			}
+			continue
+		}
+		require.ErrorIs(t, parse(cr), io.ErrUnexpectedEOF)
+	}
+}
+
 func TestParseAddressAssignCapsule(t *testing.T) {
 	addr1 := quicvarint.Append(nil, 1337) // Request ID
 	addr1 = append(addr1, 4)              // IPv4
@@ -107,35 +129,27 @@ func testParseAddressCapsuleInvalid(t *testing.T, typ http3.CapsuleType, f func(
 	})
 
 	t.Run("incomplete capsule", func(t *testing.T) {
-		addr1 := quicvarint.Append(nil, 1337) // Request ID
-		addr1 = append(addr1, 4)              // IPv4
-		addr1 = append(addr1, netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice()...)
-		addr1 = append(addr1, 32)             // IP Prefix Length
-		addr2 := quicvarint.Append(nil, 1338) // Request ID
-		addr2 = append(addr2, 6)              // IPv6
-		addr2 = append(addr2, netip.MustParseAddr("2001:db8::1").AsSlice()...)
-		addr2 = append(addr2, 128) // IP Prefix Length
-		data := quicvarint.Append(nil, uint64(typ))
-		data = quicvarint.Append(data, uint64(len(addr1)+len(addr2))) // Length
-		data = append(data, addr1...)
-		data = append(data, addr2...)
-
-		_, cr, err := http3.NewCapsuleParser(bytes.NewReader(data)).Next()
-		require.NoError(t, err)
-		require.NoError(t, f(cr))
-		for i := range data {
-			_, cr, err := http3.NewCapsuleParser(bytes.NewReader(data[:i])).Next()
-			if err != nil {
-				if i == 0 {
-					require.ErrorIs(t, err, io.EOF)
-				} else {
-					require.ErrorIs(t, err, io.ErrUnexpectedEOF)
-				}
-				continue
-			}
-			_, err = parseAddressAssignCapsule(cr)
-			require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+		var data []byte
+		switch typ {
+		case capsuleTypeAddressAssign:
+			data = (&addressAssignCapsule{
+				AssignedAddresses: []AssignedAddress{
+					{RequestID: 1337, IPPrefix: netip.MustParsePrefix("1.2.3.4/32")},
+					{RequestID: 1338, IPPrefix: netip.MustParsePrefix("2001:db8::1/128")},
+				},
+			}).append(nil)
+		case capsuleTypeAddressRequest:
+			data = (&addressRequestCapsule{
+				RequestedAddresses: []RequestedAddress{
+					{RequestID: 1337, IPPrefix: netip.MustParsePrefix("1.2.3.4/32")},
+					{RequestID: 1338, IPPrefix: netip.MustParsePrefix("2001:db8::1/128")},
+				},
+			}).append(nil)
+		default:
+			t.Fatalf("unexpected capsule type: %d", typ)
 		}
+
+		testIncompleteCapsule(t, data, func(r http3.CapsuleReader) error { return f(r) })
 	})
 }
 
@@ -271,40 +285,17 @@ func TestParseRouteAdvertisementCapsuleInvalid(t *testing.T) {
 	})
 
 	t.Run("incomplete capsule", func(t *testing.T) {
-		iprange1 := []byte{4}                                                          // IPv4
-		iprange1 = append(iprange1, netip.AddrFrom4([4]byte{1, 1, 1, 1}).AsSlice()...) // Start IP
-		iprange1 = append(iprange1, netip.AddrFrom4([4]byte{2, 2, 2, 2}).AsSlice()...) // End IP
-		iprange1 = append(iprange1, 13)                                                // IP Protocol
+		data := (&routeAdvertisementCapsule{
+			IPAddressRanges: []IPRoute{
+				{StartIP: netip.MustParseAddr("1.1.1.1"), EndIP: netip.MustParseAddr("2.2.2.2"), IPProtocol: 13},
+				{StartIP: netip.MustParseAddr("2001:db8::1"), EndIP: netip.MustParseAddr("2001:db8::100"), IPProtocol: 37},
+			},
+		}).append(nil)
 
-		iprange2 := []byte{6}                                                          // IPv6
-		iprange2 = append(iprange2, netip.MustParseAddr("2001:db8::1").AsSlice()...)   // Start IP
-		iprange2 = append(iprange2, netip.MustParseAddr("2001:db8::100").AsSlice()...) // End IP
-		iprange2 = append(iprange2, 37)                                                // IP Protocol
-
-		data := quicvarint.Append(nil, uint64(capsuleTypeRouteAdvertisement))
-		data = quicvarint.Append(data, uint64(len(iprange1)+len(iprange2))) // Length
-		data = append(data, iprange1...)
-		data = append(data, iprange2...)
-
-		r := bytes.NewReader(data)
-		_, cr, err := http3.NewCapsuleParser(r).Next()
-		require.NoError(t, err)
-		_, err = parseRouteAdvertisementCapsule(cr)
-		require.NoError(t, err)
-		require.Zero(t, r.Len())
-		for i := range data {
-			_, cr, err := http3.NewCapsuleParser(bytes.NewReader(data[:i])).Next()
-			if err != nil {
-				if i == 0 {
-					require.ErrorIs(t, err, io.EOF)
-				} else {
-					require.ErrorIs(t, err, io.ErrUnexpectedEOF)
-				}
-				continue
-			}
-			_, err = parseRouteAdvertisementCapsule(cr)
-			require.ErrorIs(t, err, io.ErrUnexpectedEOF)
-		}
+		testIncompleteCapsule(t, data, func(r http3.CapsuleReader) error {
+			_, err := parseRouteAdvertisementCapsule(r)
+			return err
+		})
 	})
 }
 
@@ -473,6 +464,31 @@ func TestParseDNSAssignCapsuleInvalid(t *testing.T) {
 		require.ErrorIs(t, err, io.ErrUnexpectedEOF)
 		require.Equal(t, int64(len("short")), r.Remaining())
 	})
+
+	t.Run("incomplete capsule", func(t *testing.T) {
+		data := (&dnsAssignCapsule{DNSConfigurations: []DNSConfiguration{
+			{
+				Nameservers: []DNSNameserver{{
+					ServicePriority:          1,
+					IPv4Addresses:            []netip.Addr{netip.MustParseAddr("192.0.2.53")},
+					IPv6Addresses:            []netip.Addr{netip.MustParseAddr("2001:db8::53")},
+					AuthenticationDomainName: "resolver.example",
+					ServiceParameters:        []byte{0, 3, 0, 2, 0x21, 0x35},
+				}},
+				InternalDomains: []string{"internal.example"},
+				SearchDomains:   []string{"internal.example", "example"},
+			},
+			{
+				Nameservers:     []DNSNameserver{{ServicePriority: 2}},
+				InternalDomains: []string{"other.example"},
+			},
+		}}).append(nil)
+
+		testIncompleteCapsule(t, data, func(r http3.CapsuleReader) error {
+			_, err := parseDNSAssignCapsule(r)
+			return err
+		})
+	})
 }
 
 func TestParsePREF64Capsule(t *testing.T) {
@@ -545,5 +561,17 @@ func TestParsePREF64CapsuleInvalid(t *testing.T) {
 	t.Run("length not a multiple of 13", func(t *testing.T) {
 		_, err := parsePREF64Capsule(newCapsuleReader(t, capsuleTypePREF64, make([]byte, 12)))
 		require.ErrorContains(t, err, "length is not a multiple of 13")
+	})
+
+	t.Run("incomplete capsule", func(t *testing.T) {
+		data := (&pref64Capsule{Prefixes: []netip.Prefix{
+			netip.MustParsePrefix("64:ff9b::/96"),
+			netip.MustParsePrefix("2001:db8::/32"),
+		}}).append(nil)
+
+		testIncompleteCapsule(t, data, func(r http3.CapsuleReader) error {
+			_, err := parsePREF64Capsule(r)
+			return err
+		})
 	})
 }

--- a/capsule_test.go
+++ b/capsule_test.go
@@ -479,7 +479,10 @@ func TestParseDNSAssignCapsuleInvalid(t *testing.T) {
 				SearchDomains:   []string{"internal.example", "example"},
 			},
 			{
-				Nameservers:     []DNSNameserver{{ServicePriority: 2}},
+				Nameservers: []DNSNameserver{{
+					ServicePriority: 2,
+					IPv4Addresses:   []netip.Addr{netip.MustParseAddr("198.51.100.53")},
+				}},
 				InternalDomains: []string{"other.example"},
 			},
 		}}).append(nil)

--- a/capsule_test.go
+++ b/capsule_test.go
@@ -339,15 +339,7 @@ func TestParseDNSAssignCapsule(t *testing.T) {
 	payload = appendDomain(payload, "other.example")
 	payload = quicvarint.Append(payload, 0)
 
-	data := quicvarint.Append(nil, uint64(capsuleTypeDNSAssign))
-	data = quicvarint.Append(data, uint64(len(payload)))
-	data = append(data, payload...)
-
-	r := bytes.NewReader(data)
-	typ, cr, err := http3.NewCapsuleParser(r).Next()
-	require.NoError(t, err)
-	require.Equal(t, capsuleTypeDNSAssign, typ)
-	capsule, err := parseDNSAssignCapsule(cr)
+	capsule, err := parseDNSAssignCapsule(newCapsuleReader(t, capsuleTypeDNSAssign, payload))
 	require.NoError(t, err)
 	require.Equal(t, &dnsAssignCapsule{
 		DNSConfigurations: []DNSConfiguration{
@@ -372,7 +364,6 @@ func TestParseDNSAssignCapsule(t *testing.T) {
 			},
 		},
 	}, capsule)
-	require.Zero(t, r.Len())
 }
 
 func TestWriteDNSAssignCapsule(t *testing.T) {

--- a/capsule_test.go
+++ b/capsule_test.go
@@ -496,13 +496,13 @@ func TestParseDNSAssignCapsuleInvalid(t *testing.T) {
 
 func TestParsePREF64Capsule(t *testing.T) {
 	data := []byte{96, 0x00, 0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0}
-	data = append(data, 32, 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0)
+	data = append(data, 32, 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 1, 0, 0)
 
 	capsule, err := parsePREF64Capsule(newCapsuleReader(t, capsuleTypePREF64, data))
 	require.NoError(t, err)
 	require.Equal(t, &pref64Capsule{Prefixes: []netip.Prefix{
 		netip.MustParsePrefix("64:ff9b::/96"),
-		netip.MustParsePrefix("2001:db8::/32"),
+		netip.MustParsePrefix("2001:db8:0:0:1::/32"),
 	}}, capsule)
 }
 
@@ -553,12 +553,6 @@ func TestParsePREF64CapsuleInvalid(t *testing.T) {
 	t.Run("invalid prefix length", func(t *testing.T) {
 		_, err := parsePREF64Capsule(newCapsuleReader(t, capsuleTypePREF64, make([]byte, 13)))
 		require.ErrorContains(t, err, "invalid NAT64 prefix length: 0")
-	})
-
-	t.Run("non-zero host bits", func(t *testing.T) {
-		data := []byte{64, 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 1, 0, 0, 0}
-		_, err := parsePREF64Capsule(newCapsuleReader(t, capsuleTypePREF64, data))
-		require.ErrorContains(t, err, "lower bits not covered")
 	})
 
 	t.Run("IPv4-mapped IPv6 prefix", func(t *testing.T) {

--- a/capsule_test.go
+++ b/capsule_test.go
@@ -2,6 +2,7 @@ package connectip
 
 import (
 	"bytes"
+	"encoding/binary"
 	"io"
 	"net/netip"
 	"testing"
@@ -11,6 +12,18 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
+
+func newCapsuleReader(t *testing.T, typ http3.CapsuleType, payload []byte) http3.CapsuleReader {
+	t.Helper()
+
+	data := quicvarint.Append(nil, uint64(typ))
+	data = quicvarint.Append(data, uint64(len(payload)))
+	data = append(data, payload...)
+	parsedType, cr, err := http3.NewCapsuleParser(bytes.NewReader(data)).Next()
+	require.NoError(t, err)
+	require.Equal(t, typ, parsedType)
+	return cr
+}
 
 func TestParseAddressAssignCapsule(t *testing.T) {
 	addr1 := quicvarint.Append(nil, 1337) // Request ID
@@ -74,13 +87,7 @@ func testParseAddressCapsuleInvalid(t *testing.T, typ http3.CapsuleType, f func(
 		addr1 = append(addr1, 5)              // Invalid IP version (not 4 or 6)
 		addr1 = append(addr1, netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice()...)
 		addr1 = append(addr1, 32) // IP Prefix Length
-		data := quicvarint.Append(nil, uint64(typ))
-		data = quicvarint.Append(data, uint64(len(addr1))) // Length
-		data = append(data, addr1...)
-
-		_, cr, err := http3.NewCapsuleParser(bytes.NewReader(data)).Next()
-		require.NoError(t, err)
-		require.ErrorContains(t, f(cr), "invalid IP version: 5")
+		require.ErrorContains(t, f(newCapsuleReader(t, typ, addr1)), "invalid IP version: 5")
 	})
 
 	t.Run("invalid prefix length", func(t *testing.T) {
@@ -88,13 +95,7 @@ func testParseAddressCapsuleInvalid(t *testing.T, typ http3.CapsuleType, f func(
 		addr1 = append(addr1, 4)              // IPv4
 		addr1 = append(addr1, netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice()...)
 		addr1 = append(addr1, 33) // too long IP Prefix Length
-		data := quicvarint.Append(nil, uint64(typ))
-		data = quicvarint.Append(data, uint64(len(addr1))) // Length
-		data = append(data, addr1...)
-
-		_, cr, err := http3.NewCapsuleParser(bytes.NewReader(data)).Next()
-		require.NoError(t, err)
-		require.ErrorContains(t, f(cr), "prefix length 33 exceeds IP address length (32)")
+		require.ErrorContains(t, f(newCapsuleReader(t, typ, addr1)), "prefix length 33 exceeds IP address length (32)")
 	})
 
 	t.Run("lower bits not covered by prefix length are not all zero", func(t *testing.T) {
@@ -102,13 +103,7 @@ func testParseAddressCapsuleInvalid(t *testing.T, typ http3.CapsuleType, f func(
 		addr1 = append(addr1, 4)                                                 // IPv4
 		addr1 = append(addr1, netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice()...) // non-zero lower bits
 		addr1 = append(addr1, 28)                                                // IP Prefix Length
-		data := quicvarint.Append(nil, uint64(typ))
-		data = quicvarint.Append(data, uint64(len(addr1))) // Length
-		data = append(data, addr1...)
-
-		_, cr, err := http3.NewCapsuleParser(bytes.NewReader(data)).Next()
-		require.NoError(t, err)
-		require.ErrorContains(t, f(cr), "lower bits not covered by prefix length are not all zero")
+		require.ErrorContains(t, f(newCapsuleReader(t, typ, addr1)), "lower bits not covered by prefix length are not all zero")
 	})
 
 	t.Run("incomplete capsule", func(t *testing.T) {
@@ -262,12 +257,7 @@ func TestParseRouteAdvertisementCapsuleInvalid(t *testing.T) {
 		iprange1 = append(iprange1, netip.AddrFrom4([4]byte{1, 1, 1, 1}).AsSlice()...) // Start IP
 		iprange1 = append(iprange1, netip.AddrFrom4([4]byte{1, 1, 1, 2}).AsSlice()...) // End IP
 		iprange1 = append(iprange1, 13)                                                // IP Protocol
-		data := quicvarint.Append(nil, uint64(capsuleTypeRouteAdvertisement))
-		data = quicvarint.Append(data, uint64(len(iprange1))) // Length
-		data = append(data, iprange1...)
-		_, cr, err := http3.NewCapsuleParser(bytes.NewReader(data)).Next()
-		require.NoError(t, err)
-		_, err = parseRouteAdvertisementCapsule(cr)
+		_, err := parseRouteAdvertisementCapsule(newCapsuleReader(t, capsuleTypeRouteAdvertisement, iprange1))
 		require.ErrorContains(t, err, "invalid IP version: 5")
 	})
 
@@ -276,13 +266,7 @@ func TestParseRouteAdvertisementCapsuleInvalid(t *testing.T) {
 		iprange1 = append(iprange1, netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice()...) // Start IP
 		iprange1 = append(iprange1, netip.AddrFrom4([4]byte{1, 1, 1, 1}).AsSlice()...) // End IP
 		iprange1 = append(iprange1, 13)                                                // IP Protocol
-		data := quicvarint.Append(nil, uint64(capsuleTypeRouteAdvertisement))
-		data = quicvarint.Append(data, uint64(len(iprange1))) // Length
-		data = append(data, iprange1...)
-
-		_, cr, err := http3.NewCapsuleParser(bytes.NewReader(data)).Next()
-		require.NoError(t, err)
-		_, err = parseRouteAdvertisementCapsule(cr)
+		_, err := parseRouteAdvertisementCapsule(newCapsuleReader(t, capsuleTypeRouteAdvertisement, iprange1))
 		require.ErrorContains(t, err, "start IP is greater than end IP")
 	})
 
@@ -321,5 +305,203 @@ func TestParseRouteAdvertisementCapsuleInvalid(t *testing.T) {
 			_, err = parseRouteAdvertisementCapsule(cr)
 			require.ErrorIs(t, err, io.ErrUnexpectedEOF)
 		}
+	})
+}
+
+func TestParseDNSAssignCapsule(t *testing.T) {
+	var payload []byte
+	payload = quicvarint.Append(payload, 1) // Nameserver Count
+	payload = binary.BigEndian.AppendUint16(payload, 42)
+	payload = quicvarint.Append(payload, 1) // IPv4 Address Count
+	payload = append(payload, netip.MustParseAddr("192.0.2.33").AsSlice()...)
+	payload = quicvarint.Append(payload, 1) // IPv6 Address Count
+	payload = append(payload, netip.MustParseAddr("2001:db8::1").AsSlice()...)
+	payload = appendDomain(payload, "resolver.example")
+	serviceParameters := []byte{0, 3, 0, 2, 0x21, 0x35} // port=853
+	payload = quicvarint.Append(payload, uint64(len(serviceParameters)))
+	payload = append(payload, serviceParameters...)
+	payload = quicvarint.Append(payload, 1) // Internal Domain Count
+	payload = appendDomain(payload, "internal.example")
+	payload = quicvarint.Append(payload, 2) // Search Domain Count
+	payload = appendDomain(payload, "internal.example")
+	payload = appendDomain(payload, "example")
+
+	// A DNS_ASSIGN capsule can carry another configuration for a different
+	// internal domain.
+	payload = quicvarint.Append(payload, 1)
+	payload = binary.BigEndian.AppendUint16(payload, 1)
+	payload = quicvarint.Append(payload, 1)
+	payload = append(payload, netip.MustParseAddr("198.51.100.53").AsSlice()...)
+	payload = quicvarint.Append(payload, 0)
+	payload = appendDomain(payload, "")
+	payload = quicvarint.Append(payload, 0) // Service Parameters Length
+	payload = quicvarint.Append(payload, 1)
+	payload = appendDomain(payload, "other.example")
+	payload = quicvarint.Append(payload, 0)
+
+	data := quicvarint.Append(nil, uint64(capsuleTypeDNSAssign))
+	data = quicvarint.Append(data, uint64(len(payload)))
+	data = append(data, payload...)
+
+	r := bytes.NewReader(data)
+	typ, cr, err := http3.NewCapsuleParser(r).Next()
+	require.NoError(t, err)
+	require.Equal(t, capsuleTypeDNSAssign, typ)
+	capsule, err := parseDNSAssignCapsule(cr)
+	require.NoError(t, err)
+	require.Equal(t, &dnsAssignCapsule{
+		DNSConfigurations: []DNSConfiguration{
+			{
+				Nameservers: []DNSNameserver{{
+					ServicePriority:          42,
+					IPv4Addresses:            []netip.Addr{netip.MustParseAddr("192.0.2.33")},
+					IPv6Addresses:            []netip.Addr{netip.MustParseAddr("2001:db8::1")},
+					AuthenticationDomainName: "resolver.example",
+					ServiceParameters:        serviceParameters,
+				}},
+				InternalDomains: []string{"internal.example"},
+				SearchDomains:   []string{"internal.example", "example"},
+			},
+			{
+				Nameservers: []DNSNameserver{{
+					ServicePriority:          1,
+					IPv4Addresses:            []netip.Addr{netip.MustParseAddr("198.51.100.53")},
+					AuthenticationDomainName: "",
+				}},
+				InternalDomains: []string{"other.example"},
+			},
+		},
+	}, capsule)
+	require.Zero(t, r.Len())
+}
+
+func TestWriteDNSAssignCapsule(t *testing.T) {
+	capsule := &dnsAssignCapsule{DNSConfigurations: []DNSConfiguration{
+		{
+			Nameservers: []DNSNameserver{{
+				ServicePriority:          1,
+				AuthenticationDomainName: "masque.example.org",
+				ServiceParameters:        []byte{0, 1, 0, 3, 2, 'h', '3'},
+			}},
+			InternalDomains: []string{""},
+		},
+		{
+			Nameservers: []DNSNameserver{{
+				ServicePriority: 2,
+				IPv4Addresses:   []netip.Addr{netip.MustParseAddr("192.0.2.53")},
+			}},
+			InternalDomains: []string{"internal.example"},
+			SearchDomains:   []string{"internal.example", "example"},
+		},
+	}}
+
+	r := bytes.NewReader(capsule.append(nil))
+	typ, cr, err := http3.NewCapsuleParser(r).Next()
+	require.NoError(t, err)
+	require.Equal(t, capsuleTypeDNSAssign, typ)
+	parsed, err := parseDNSAssignCapsule(cr)
+	require.NoError(t, err)
+	require.Equal(t, capsule, parsed)
+	require.Zero(t, r.Len())
+}
+
+func TestParseDNSAssignCapsuleInvalid(t *testing.T) {
+	t.Run("zero service priority", func(t *testing.T) {
+		payload := quicvarint.Append(nil, 1)
+		payload = append(payload, 0, 0)
+		payload = quicvarint.Append(payload, 0)
+		payload = quicvarint.Append(payload, 0)
+		payload = appendDomain(payload, "")
+		payload = quicvarint.Append(payload, 0)
+		payload = quicvarint.Append(payload, 0)
+		payload = quicvarint.Append(payload, 0)
+
+		_, err := parseDNSAssignCapsule(newCapsuleReader(t, capsuleTypeDNSAssign, payload))
+		require.ErrorContains(t, err, "service priority must not be zero")
+	})
+
+	t.Run("truncated domain", func(t *testing.T) {
+		payload := quicvarint.Append(nil, 0) // Nameserver Count
+		payload = quicvarint.Append(payload, 1)
+		payload = quicvarint.Append(payload, 10)
+		payload = append(payload, "short"...)
+
+		_, err := parseDNSAssignCapsule(newCapsuleReader(t, capsuleTypeDNSAssign, payload))
+		require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	})
+
+	t.Run("domain length limit", func(t *testing.T) {
+		payload := quicvarint.Append(nil, 0) // Nameserver Count
+		payload = quicvarint.Append(payload, 1)
+		payload = quicvarint.Append(payload, 1<<30)
+
+		_, err := parseDNSAssignCapsule(newCapsuleReader(t, capsuleTypeDNSAssign, payload))
+		require.ErrorContains(t, err, "domain name too long")
+	})
+
+	t.Run("service parameters length limit", func(t *testing.T) {
+		payload := quicvarint.Append(nil, 1) // Nameserver Count
+		payload = binary.BigEndian.AppendUint16(payload, 1)
+		payload = quicvarint.Append(payload, 0) // IPv4 Address Count
+		payload = quicvarint.Append(payload, 0) // IPv6 Address Count
+		payload = appendDomain(payload, "")
+		payload = quicvarint.Append(payload, 1<<30)
+
+		_, err := parseDNSAssignCapsule(newCapsuleReader(t, capsuleTypeDNSAssign, payload))
+		require.ErrorContains(t, err, "service parameters too long")
+	})
+}
+
+func TestParsePREF64Capsule(t *testing.T) {
+	data := []byte{96, 0x00, 0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0}
+	data = append(data, 32, 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0)
+
+	capsule, err := parsePREF64Capsule(newCapsuleReader(t, capsuleTypePREF64, data))
+	require.NoError(t, err)
+	require.Equal(t, &pref64Capsule{Prefixes: []netip.Prefix{
+		netip.MustParsePrefix("64:ff9b::/96"),
+		netip.MustParsePrefix("2001:db8::/32"),
+	}}, capsule)
+}
+
+func TestWritePREF64Capsule(t *testing.T) {
+	capsule := &pref64Capsule{Prefixes: []netip.Prefix{
+		netip.MustParsePrefix("64:ff9b::/96"),
+		netip.MustParsePrefix("2001:db8:1200::/40"),
+	}}
+	r := bytes.NewReader(capsule.append(nil))
+	typ, cr, err := http3.NewCapsuleParser(r).Next()
+	require.NoError(t, err)
+	require.Equal(t, capsuleTypePREF64, typ)
+	parsed, err := parsePREF64Capsule(cr)
+	require.NoError(t, err)
+	require.Equal(t, capsule, parsed)
+	require.Zero(t, r.Len())
+}
+
+func TestWriteEmptyPREF64Capsule(t *testing.T) {
+	data := (&pref64Capsule{}).append(nil)
+	_, cr, err := http3.NewCapsuleParser(bytes.NewReader(data)).Next()
+	require.NoError(t, err)
+	parsed, err := parsePREF64Capsule(cr)
+	require.NoError(t, err)
+	require.Empty(t, parsed.Prefixes)
+}
+
+func TestParsePREF64CapsuleInvalid(t *testing.T) {
+	t.Run("invalid prefix length", func(t *testing.T) {
+		_, err := parsePREF64Capsule(newCapsuleReader(t, capsuleTypePREF64, make([]byte, 13)))
+		require.ErrorContains(t, err, "invalid NAT64 prefix length: 0")
+	})
+
+	t.Run("non-zero host bits", func(t *testing.T) {
+		data := []byte{64, 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 1, 0, 0, 0}
+		_, err := parsePREF64Capsule(newCapsuleReader(t, capsuleTypePREF64, data))
+		require.ErrorContains(t, err, "lower bits not covered")
+	})
+
+	t.Run("length not a multiple of 13", func(t *testing.T) {
+		_, err := parsePREF64Capsule(newCapsuleReader(t, capsuleTypePREF64, make([]byte, 12)))
+		require.ErrorContains(t, err, "length is not a multiple of 13")
 	})
 }

--- a/capsule_test.go
+++ b/capsule_test.go
@@ -561,6 +561,12 @@ func TestParsePREF64CapsuleInvalid(t *testing.T) {
 		require.ErrorContains(t, err, "lower bits not covered")
 	})
 
+	t.Run("IPv4-mapped IPv6 prefix", func(t *testing.T) {
+		data := []byte{96, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff}
+		_, err := parsePREF64Capsule(newCapsuleReader(t, capsuleTypePREF64, data))
+		require.ErrorContains(t, err, "IPv4-mapped IPv6 addresses are not valid NAT64 prefixes")
+	})
+
 	t.Run("length not a multiple of 13", func(t *testing.T) {
 		_, err := parsePREF64Capsule(newCapsuleReader(t, capsuleTypePREF64, make([]byte, 12)))
 		require.ErrorContains(t, err, "length is not a multiple of 13")

--- a/capsule_test.go
+++ b/capsule_test.go
@@ -397,6 +397,13 @@ func TestWriteDNSAssignCapsule(t *testing.T) {
 }
 
 func TestParseDNSAssignCapsuleInvalid(t *testing.T) {
+	t.Run("capsule size limit", func(t *testing.T) {
+		payload := make([]byte, maxDNSAssignCapsuleSize+1)
+
+		_, err := parseDNSAssignCapsule(newCapsuleReader(t, capsuleTypeDNSAssign, payload))
+		require.ErrorContains(t, err, "DNS_ASSIGN capsule too large")
+	})
+
 	t.Run("zero service priority", func(t *testing.T) {
 		payload := quicvarint.Append(nil, 1)
 		payload = append(payload, 0, 0)
@@ -450,6 +457,21 @@ func TestParseDNSAssignCapsuleInvalid(t *testing.T) {
 
 		_, err := parseDNSAssignCapsule(newCapsuleReader(t, capsuleTypeDNSAssign, payload))
 		require.ErrorContains(t, err, "service parameters too long")
+	})
+
+	t.Run("truncated service parameters", func(t *testing.T) {
+		payload := quicvarint.Append(nil, 1) // Nameserver Count
+		payload = binary.BigEndian.AppendUint16(payload, 1)
+		payload = quicvarint.Append(payload, 0) // IPv4 Address Count
+		payload = quicvarint.Append(payload, 0) // IPv6 Address Count
+		payload = appendDomain(payload, "")
+		payload = quicvarint.Append(payload, 10)
+		payload = append(payload, "short"...)
+		r := newCapsuleReader(t, capsuleTypeDNSAssign, payload)
+
+		_, err := parseDNSAssignCapsule(r)
+		require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+		require.Equal(t, int64(len("short")), r.Remaining())
 	})
 }
 

--- a/capsule_test.go
+++ b/capsule_test.go
@@ -382,7 +382,7 @@ func TestWriteDNSAssignCapsule(t *testing.T) {
 				IPv4Addresses:   []netip.Addr{netip.MustParseAddr("192.0.2.53")},
 			}},
 			InternalDomains: []string{"internal.example"},
-			SearchDomains:   []string{"internal.example", "example"},
+			SearchDomains:   []string{"internal.example", "XN--BCHER-KVA.example"},
 		},
 	}}
 
@@ -428,6 +428,16 @@ func TestParseDNSAssignCapsuleInvalid(t *testing.T) {
 
 		_, err := parseDNSAssignCapsule(newCapsuleReader(t, capsuleTypeDNSAssign, payload))
 		require.ErrorContains(t, err, "domain name too long")
+	})
+
+	t.Run("domain must use A-label form", func(t *testing.T) {
+		payload := quicvarint.Append(nil, 0) // Nameserver Count
+		payload = quicvarint.Append(payload, 1)
+		payload = appendDomain(payload, "bücher.example")
+		payload = quicvarint.Append(payload, 0)
+
+		_, err := parseDNSAssignCapsule(newCapsuleReader(t, capsuleTypeDNSAssign, payload))
+		require.ErrorContains(t, err, "invalid internal domain name: must use IDNA A-label form")
 	})
 
 	t.Run("service parameters length limit", func(t *testing.T) {

--- a/capsule_test.go
+++ b/capsule_test.go
@@ -521,7 +521,7 @@ func TestParsePREF64CapsuleLimit(t *testing.T) {
 		_, err := parsePREF64Capsule(newCapsuleReader(
 			t, capsuleTypePREF64, bytes.Repeat(prefix, maxPREF64Prefixes+1),
 		))
-		require.ErrorContains(t, err, "PREF64 capsule contains too many prefixes: 65 (maximum 64)")
+		require.ErrorContains(t, err, "PREF64 capsule contains too many prefixes: 257 (maximum 256)")
 	})
 }
 

--- a/capsule_test.go
+++ b/capsule_test.go
@@ -487,6 +487,25 @@ func TestParsePREF64Capsule(t *testing.T) {
 	}}, capsule)
 }
 
+func TestParsePREF64CapsuleLimit(t *testing.T) {
+	prefix := []byte{96, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+
+	t.Run("at limit", func(t *testing.T) {
+		capsule, err := parsePREF64Capsule(newCapsuleReader(
+			t, capsuleTypePREF64, bytes.Repeat(prefix, maxPREF64Prefixes),
+		))
+		require.NoError(t, err)
+		require.Len(t, capsule.Prefixes, maxPREF64Prefixes)
+	})
+
+	t.Run("over limit", func(t *testing.T) {
+		_, err := parsePREF64Capsule(newCapsuleReader(
+			t, capsuleTypePREF64, bytes.Repeat(prefix, maxPREF64Prefixes+1),
+		))
+		require.ErrorContains(t, err, "PREF64 capsule contains too many prefixes: 65 (maximum 64)")
+	})
+}
+
 func TestWritePREF64Capsule(t *testing.T) {
 	capsule := &pref64Capsule{Prefixes: []netip.Prefix{
 		netip.MustParsePrefix("64:ff9b::/96"),

--- a/conn.go
+++ b/conn.go
@@ -210,9 +210,6 @@ func (c *Conn) SendPREF64Configuration(prefixes []netip.Prefix) error {
 		default:
 			return fmt.Errorf("invalid NAT64 prefix %d: invalid prefix length %d", i, prefix.Bits())
 		}
-		if prefix != prefix.Masked() {
-			return fmt.Errorf("invalid NAT64 prefix %d: lower bits not covered by prefix length are not all zero", i)
-		}
 	}
 	return c.sendCapsule((&pref64Capsule{Prefixes: prefixes}).append(nil))
 }

--- a/conn.go
+++ b/conn.go
@@ -59,8 +59,10 @@ type Conn struct {
 	closeConn   func() error
 	writeNotify chan struct{}
 
-	assignedAddressUpdates chan []netip.Prefix
-	availableRouteUpdates  chan []IPRoute
+	assignedAddressUpdates  chan []netip.Prefix
+	availableRouteUpdates   chan []IPRoute
+	dnsConfigurationUpdates chan []DNSConfiguration
+	pref64Updates           chan []netip.Prefix
 
 	mu sync.Mutex
 	// queuedCapsules contains the capsules serialized by the send methods. This
@@ -76,12 +78,14 @@ type Conn struct {
 
 func newProxiedConn(str http3Stream, closeConn func() error) *Conn {
 	c := &Conn{
-		str:                    str,
-		closeConn:              closeConn,
-		writeNotify:            make(chan struct{}, 1),
-		assignedAddressUpdates: make(chan []netip.Prefix, 1),
-		availableRouteUpdates:  make(chan []IPRoute, 1),
-		closeChan:              make(chan struct{}),
+		str:                     str,
+		closeConn:               closeConn,
+		writeNotify:             make(chan struct{}, 1),
+		assignedAddressUpdates:  make(chan []netip.Prefix, 1),
+		availableRouteUpdates:   make(chan []IPRoute, 1),
+		dnsConfigurationUpdates: make(chan []DNSConfiguration, 1),
+		pref64Updates:           make(chan []netip.Prefix, 1),
+		closeChan:               make(chan struct{}),
 	}
 	go func() {
 		if err := c.readFromStream(); err != nil {
@@ -154,6 +158,80 @@ func (c *Conn) AssignAddresses(prefixes []netip.Prefix) error {
 	if err == nil {
 		c.peerAddresses = slices.Clone(prefixes)
 	}
+	c.mu.Unlock()
+	if err != nil {
+		_ = c.Close()
+		return err
+	}
+	return nil
+}
+
+// SendDNSConfiguration schedules a DNS configuration update to the peer.
+// It returns once the update has been queued. The update supersedes the DNS
+// configuration previously sent on this connection.
+func (c *Conn) SendDNSConfiguration(configurations []DNSConfiguration) error {
+	for _, config := range configurations {
+		if err := config.validate(); err != nil {
+			return fmt.Errorf("invalid DNS configuration: %w", err)
+		}
+	}
+	return c.sendCapsule((&dnsAssignCapsule{DNSConfigurations: configurations}).append(nil))
+}
+
+// ReceiveDNSConfiguration waits for the next DNS configuration update from the peer.
+// Each update supersedes the preceding one.
+func (c *Conn) ReceiveDNSConfiguration(ctx context.Context) ([]DNSConfiguration, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-c.closeChan:
+		return nil, c.closeErr
+	case configurations := <-c.dnsConfigurationUpdates:
+		return configurations, nil
+	}
+}
+
+// SendPREF64Configuration schedules an update of the NAT64 prefixes to use for
+// IPv6/IPv4 address synthesis. It returns once the update has been queued. An
+// empty slice clears the previously sent configuration.
+func (c *Conn) SendPREF64Configuration(prefixes []netip.Prefix) error {
+	for i, prefix := range prefixes {
+		if !prefix.IsValid() || !prefix.Addr().Is6() || prefix.Addr().Is4In6() {
+			return fmt.Errorf("invalid NAT64 prefix %d: not an IPv6 prefix", i)
+		}
+		switch prefix.Bits() {
+		case 32, 40, 48, 56, 64, 96:
+		default:
+			return fmt.Errorf("invalid NAT64 prefix %d: invalid prefix length %d", i, prefix.Bits())
+		}
+		if prefix != prefix.Masked() {
+			return fmt.Errorf("invalid NAT64 prefix %d: lower bits not covered by prefix length are not all zero", i)
+		}
+	}
+	return c.sendCapsule((&pref64Capsule{Prefixes: prefixes}).append(nil))
+}
+
+// ReceivePREF64Configuration waits for the next NAT64 prefix update from the
+// peer. An empty slice means that NAT64 prefixes are not available.
+func (c *Conn) ReceivePREF64Configuration(ctx context.Context) ([]netip.Prefix, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-c.closeChan:
+		return nil, c.closeErr
+	case prefixes := <-c.pref64Updates:
+		return prefixes, nil
+	}
+}
+
+func (c *Conn) sendCapsule(capsuleData []byte) error {
+	c.mu.Lock()
+	if c.closeErr != nil {
+		err := c.closeErr
+		c.mu.Unlock()
+		return err
+	}
+	err := c.queueCapsule(capsuleData)
 	c.mu.Unlock()
 	if err != nil {
 		_ = c.Close()
@@ -250,6 +328,18 @@ func (c *Conn) readFromStream() error {
 				return err
 			}
 			queueLatest(c.availableRouteUpdates, capsule.IPAddressRanges)
+		case capsuleTypeDNSAssign:
+			capsule, err := parseDNSAssignCapsule(cr)
+			if err != nil {
+				return err
+			}
+			queueLatest(c.dnsConfigurationUpdates, capsule.DNSConfigurations)
+		case capsuleTypePREF64:
+			capsule, err := parsePREF64Capsule(cr)
+			if err != nil {
+				return err
+			}
+			queueLatest(c.pref64Updates, capsule.Prefixes)
 		default:
 			if err := cr.Discard(); err != nil {
 				return err

--- a/conn.go
+++ b/conn.go
@@ -169,6 +169,12 @@ func (c *Conn) AssignAddresses(prefixes []netip.Prefix) error {
 // SendDNSConfiguration schedules a DNS configuration update to the peer.
 // It returns once the update has been queued. The update supersedes the DNS
 // configuration previously sent on this connection.
+//
+// To avoid leaking DNS traffic outside the tunnel, the application is responsible
+// for advertising the corresponding routes before calling this method. See
+// [Section 5 of draft-ietf-masque-connect-ip-dns-06].
+//
+// [Section 5 of draft-ietf-masque-connect-ip-dns-06]: https://datatracker.ietf.org/doc/html/draft-ietf-masque-connect-ip-dns-06#section-5
 func (c *Conn) SendDNSConfiguration(configurations []DNSConfiguration) error {
 	for _, config := range configurations {
 		if err := config.validate(); err != nil {

--- a/conn_test.go
+++ b/conn_test.go
@@ -170,6 +170,15 @@ func TestDNSConfiguration(t *testing.T) {
 			}),
 			"non-IPv4 address",
 		)
+		require.ErrorContains(t,
+			conn.SendDNSConfiguration([]DNSConfiguration{
+				{
+					Nameservers:     []DNSNameserver{{ServicePriority: 1}},
+					InternalDomains: []string{"bücher.example"},
+				},
+			}),
+			"invalid internal domain name: must use IDNA A-label form",
+		)
 	})
 }
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/net/ipv6"
 
 	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
 	"github.com/quic-go/quic-go/quicvarint"
 
 	"github.com/stretchr/testify/require"
@@ -36,7 +37,7 @@ var _ http3Stream = &mockStream{}
 
 func (m *mockStream) StreamID() quic.StreamID { panic("implement me") }
 func (m *mockStream) Read(p []byte) (int, error) {
-	if m.reading == nil {
+	if len(m.reading) == 0 {
 		m.reading = <-m.toRead
 	}
 	n := copy(p, m.reading)
@@ -90,6 +91,152 @@ func TestCapsuleQueueLimit(t *testing.T) {
 
 	// Let the writer finish the in-progress write and observe the closed connection.
 	<-writes
+}
+
+func TestDNSConfiguration(t *testing.T) {
+	cfg := []DNSConfiguration{
+		{
+			Nameservers: []DNSNameserver{{
+				ServicePriority:          1,
+				IPv4Addresses:            []netip.Addr{netip.MustParseAddr("192.0.2.53")},
+				IPv6Addresses:            []netip.Addr{netip.MustParseAddr("2001:db8::53")},
+				AuthenticationDomainName: "resolver.example",
+				ServiceParameters:        []byte{0, 3, 0, 2, 0x21, 0x35},
+			}},
+			InternalDomains: []string{"internal.example"},
+			SearchDomains:   []string{"internal.example", "example"},
+		},
+		{
+			Nameservers: []DNSNameserver{{
+				ServicePriority: 2,
+				IPv4Addresses:   []netip.Addr{netip.MustParseAddr("198.51.100.53")},
+			}},
+			InternalDomains: []string{"other.example"},
+		},
+	}
+
+	t.Run("send", func(t *testing.T) {
+		written := make(chan []byte)
+		writeStarted := make(chan struct{})
+		conn := newProxiedConn(&mockStream{writeStarted: writeStarted, written: written}, nil)
+		t.Cleanup(func() { conn.Close() })
+
+		require.NoError(t, conn.AssignAddresses(nil))
+		select {
+		case <-writeStarted:
+		case <-time.After(time.Second):
+			t.Fatal("capsule write did not start")
+		}
+		require.NoError(t, conn.SendDNSConfiguration(cfg))
+		cfg[0].Nameservers[0].ServicePriority = 42
+		<-written // unblock the address assignment write
+		data := <-written
+		cfg[0].Nameservers[0].ServicePriority = 1
+
+		typ, cr, err := http3.NewCapsuleParser(bytes.NewReader(data)).Next()
+		require.NoError(t, err)
+		require.Equal(t, capsuleTypeDNSAssign, typ)
+		capsule, err := parseDNSAssignCapsule(cr)
+		require.NoError(t, err)
+		require.Equal(t, cfg, capsule.DNSConfigurations)
+	})
+
+	t.Run("receive", func(t *testing.T) {
+		toRead := make(chan []byte, 1)
+		conn := newProxiedConn(&mockStream{toRead: toRead}, nil)
+		toRead <- (&dnsAssignCapsule{DNSConfigurations: cfg}).append(nil)
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		defer cancel()
+		received, err := conn.ReceiveDNSConfiguration(ctx)
+		require.NoError(t, err)
+		require.Equal(t, cfg, received)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		conn := newProxiedConn(&mockStream{}, nil)
+		require.ErrorContains(t,
+			conn.SendDNSConfiguration([]DNSConfiguration{
+				{Nameservers: []DNSNameserver{{ServicePriority: 0}}},
+			}),
+			"service priority must not be zero",
+		)
+		require.ErrorContains(t,
+			conn.SendDNSConfiguration([]DNSConfiguration{
+				{Nameservers: []DNSNameserver{{
+					ServicePriority: 1,
+					IPv4Addresses:   []netip.Addr{netip.MustParseAddr("2001:db8::1")},
+				}}},
+			}),
+			"non-IPv4 address",
+		)
+	})
+}
+
+func TestPREF64Configuration(t *testing.T) {
+	prefixes := []netip.Prefix{
+		netip.MustParsePrefix("64:ff9b::/96"),
+		netip.MustParsePrefix("2001:db8:1200::/40"),
+	}
+
+	t.Run("send", func(t *testing.T) {
+		written := make(chan []byte)
+		writeStarted := make(chan struct{})
+		conn := newProxiedConn(&mockStream{writeStarted: writeStarted, written: written}, nil)
+		t.Cleanup(func() { conn.Close() })
+
+		require.NoError(t, conn.AssignAddresses(nil))
+		select {
+		case <-writeStarted:
+		case <-time.After(time.Second):
+			t.Fatal("capsule write did not start")
+		}
+		require.NoError(t, conn.SendPREF64Configuration(prefixes))
+		prefixes[0] = netip.MustParsePrefix("2001:db8::/32")
+		<-written // unblock the address assignment write
+		data := <-written
+		prefixes[0] = netip.MustParsePrefix("64:ff9b::/96")
+
+		typ, cr, err := http3.NewCapsuleParser(bytes.NewReader(data)).Next()
+		require.NoError(t, err)
+		require.Equal(t, capsuleTypePREF64, typ)
+		capsule, err := parsePREF64Capsule(cr)
+		require.NoError(t, err)
+		require.Equal(t, prefixes, capsule.Prefixes)
+	})
+
+	t.Run("receive and clear", func(t *testing.T) {
+		toRead := make(chan []byte, 2)
+		conn := newProxiedConn(&mockStream{toRead: toRead}, nil)
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		defer cancel()
+
+		toRead <- (&pref64Capsule{Prefixes: prefixes}).append(nil)
+		received, err := conn.ReceivePREF64Configuration(ctx)
+		require.NoError(t, err)
+		require.Equal(t, prefixes, received)
+
+		toRead <- (&pref64Capsule{}).append(nil)
+		received, err = conn.ReceivePREF64Configuration(ctx)
+		require.NoError(t, err)
+		require.Empty(t, received)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		conn := newProxiedConn(&mockStream{}, nil)
+		require.ErrorContains(t,
+			conn.SendPREF64Configuration([]netip.Prefix{
+				netip.MustParsePrefix("192.0.2.0/24"),
+			}),
+			"not an IPv6 prefix",
+		)
+		require.ErrorContains(t,
+			conn.SendPREF64Configuration([]netip.Prefix{
+				netip.MustParsePrefix("2001:db8::/80"),
+			}),
+			"invalid prefix length",
+		)
+	})
 }
 
 func TestIncomingDatagrams(t *testing.T) {

--- a/conn_test.go
+++ b/conn_test.go
@@ -173,7 +173,6 @@ func TestDNSConfiguration(t *testing.T) {
 		require.ErrorContains(t,
 			conn.SendDNSConfiguration([]DNSConfiguration{
 				{
-					Nameservers:     []DNSNameserver{{ServicePriority: 1}},
 					InternalDomains: []string{"bücher.example"},
 				},
 			}),

--- a/conn_test.go
+++ b/conn_test.go
@@ -185,6 +185,7 @@ func TestPREF64Configuration(t *testing.T) {
 	prefixes := []netip.Prefix{
 		netip.MustParsePrefix("64:ff9b::/96"),
 		netip.MustParsePrefix("2001:db8:1200::/40"),
+		netip.MustParsePrefix("2001:db8:0:0:1::/32"),
 	}
 
 	t.Run("send", func(t *testing.T) {

--- a/dns.go
+++ b/dns.go
@@ -1,0 +1,69 @@
+package connectip
+
+import (
+	"errors"
+	"fmt"
+	"net/netip"
+)
+
+const (
+	// RFC 1035, Section 2.3.4 limits a domain name to 255 octets.
+	maxDomainNameLen = 255
+	// SvcParams use DNS RDATA encoding, whose RDLENGTH field is 16 bits
+	// (RFC 1035, Section 4.1.3).
+	maxServiceParametersLen = 1<<16 - 1
+)
+
+// DNSNameserver describes the Nameserver structure defined in Section 3.2 of
+// draft-ietf-masque-connect-ip-dns-06. ServiceParameters contains SvcParams in
+// the wire format defined by RFC 9460.
+type DNSNameserver struct {
+	ServicePriority          uint16
+	IPv4Addresses            []netip.Addr
+	IPv6Addresses            []netip.Addr
+	AuthenticationDomainName string
+	ServiceParameters        []byte
+}
+
+// DNSConfiguration describes the DNS Configuration structure defined in
+// Section 3.3 of draft-ietf-masque-connect-ip-dns-06. An empty internal domain
+// represents the DNS root.
+type DNSConfiguration struct {
+	Nameservers     []DNSNameserver
+	InternalDomains []string
+	SearchDomains   []string
+}
+
+func (c DNSConfiguration) validate() error {
+	for _, nameserver := range c.Nameservers {
+		switch {
+		case nameserver.ServicePriority == 0:
+			return errors.New("service priority must not be zero")
+		case len(nameserver.AuthenticationDomainName) > maxDomainNameLen:
+			return errors.New("authentication domain name too long")
+		case len(nameserver.ServiceParameters) > maxServiceParametersLen:
+			return errors.New("service parameters too long")
+		}
+		for _, addr := range nameserver.IPv4Addresses {
+			if !addr.Is4() {
+				return fmt.Errorf("non-IPv4 address in IPv4 address list: %s", addr)
+			}
+		}
+		for _, addr := range nameserver.IPv6Addresses {
+			if !addr.Is6() || addr.Is4In6() {
+				return fmt.Errorf("non-IPv6 address in IPv6 address list: %s", addr)
+			}
+		}
+	}
+	for _, domain := range c.InternalDomains {
+		if len(domain) > maxDomainNameLen {
+			return errors.New("internal domain name too long")
+		}
+	}
+	for _, domain := range c.SearchDomains {
+		if len(domain) > maxDomainNameLen {
+			return errors.New("search domain name too long")
+		}
+	}
+	return nil
+}

--- a/dns.go
+++ b/dns.go
@@ -4,6 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
+	"strings"
+	"unicode/utf8"
+
+	"golang.org/x/net/idna"
 )
 
 const (
@@ -14,35 +18,72 @@ const (
 	maxServiceParametersLen = 1<<16 - 1
 )
 
-// DNSNameserver describes the Nameserver structure defined in Section 3.2 of
-// draft-ietf-masque-connect-ip-dns-06. ServiceParameters contains SvcParams in
-// the wire format defined by RFC 9460.
+// DNSNameserver describes the Nameserver structure defined by
+// draft-ietf-masque-connect-ip-dns-06. ServiceParameters contains SvcParams
+// in the wire format defined by RFC 9460.
 type DNSNameserver struct {
-	ServicePriority          uint16
-	IPv4Addresses            []netip.Addr
-	IPv6Addresses            []netip.Addr
+	ServicePriority uint16
+	IPv4Addresses   []netip.Addr
+	IPv6Addresses   []netip.Addr
+	// AuthenticationDomainName is the fully qualified domain name of the
+	// nameserver. It must be in DNS presentation format using IDNA A-labels;
+	// U-labels are rejected. It may be empty only when the nameserver supports
+	// unencrypted DNS exclusively.
 	AuthenticationDomainName string
 	ServiceParameters        []byte
 }
 
-// DNSConfiguration describes the DNS Configuration structure defined in
-// Section 3.3 of draft-ietf-masque-connect-ip-dns-06. An empty internal domain
-// represents the DNS root.
+// DNSConfiguration describes the DNS Configuration structure defined by
+// draft-ietf-masque-connect-ip-dns-06.
 type DNSConfiguration struct {
-	Nameservers     []DNSNameserver
+	Nameservers []DNSNameserver
+	// InternalDomains contains fully qualified domain names in DNS presentation
+	// format using IDNA A-labels. U-labels are rejected. An empty string
+	// represents the DNS root.
 	InternalDomains []string
-	SearchDomains   []string
+	// SearchDomains contains fully qualified domain names in DNS presentation
+	// format using IDNA A-labels. U-labels and empty strings are rejected.
+	SearchDomains []string
+}
+
+var dnsNameProfile = idna.New(
+	idna.MapForLookup(),
+	idna.BidiRule(),
+	idna.VerifyDNSLength(true),
+)
+
+func validateDomainName(name string, allowEmpty bool) error {
+	if name == "" {
+		if allowEmpty {
+			return nil
+		}
+		return errors.New("must not be empty")
+	}
+	for i := range len(name) {
+		if name[i] >= utf8.RuneSelf {
+			return errors.New("must use IDNA A-label form")
+		}
+	}
+	ascii, err := dnsNameProfile.ToASCII(name)
+	if err != nil {
+		return fmt.Errorf("must be a valid IDNA A-label: %w", err)
+	}
+	if !strings.EqualFold(ascii, name) {
+		return errors.New("must use IDNA A-label form")
+	}
+	return nil
 }
 
 func (c DNSConfiguration) validate() error {
 	for _, nameserver := range c.Nameservers {
-		switch {
-		case nameserver.ServicePriority == 0:
+		if nameserver.ServicePriority == 0 {
 			return errors.New("service priority must not be zero")
-		case len(nameserver.AuthenticationDomainName) > maxDomainNameLen:
-			return errors.New("authentication domain name too long")
-		case len(nameserver.ServiceParameters) > maxServiceParametersLen:
+		}
+		if len(nameserver.ServiceParameters) > maxServiceParametersLen {
 			return errors.New("service parameters too long")
+		}
+		if err := validateDomainName(nameserver.AuthenticationDomainName, true); err != nil {
+			return fmt.Errorf("invalid authentication domain name: %w", err)
 		}
 		for _, addr := range nameserver.IPv4Addresses {
 			if !addr.Is4() {
@@ -56,13 +97,13 @@ func (c DNSConfiguration) validate() error {
 		}
 	}
 	for _, domain := range c.InternalDomains {
-		if len(domain) > maxDomainNameLen {
-			return errors.New("internal domain name too long")
+		if err := validateDomainName(domain, true); err != nil {
+			return fmt.Errorf("invalid internal domain name: %w", err)
 		}
 	}
 	for _, domain := range c.SearchDomains {
-		if len(domain) > maxDomainNameLen {
-			return errors.New("search domain name too long")
+		if err := validateDomainName(domain, false); err != nil {
+			return fmt.Errorf("invalid search domain name: %w", err)
 		}
 	}
 	return nil

--- a/dns.go
+++ b/dns.go
@@ -24,7 +24,9 @@ const (
 type DNSNameserver struct {
 	ServicePriority uint16
 	IPv4Addresses   []netip.Addr
-	IPv6Addresses   []netip.Addr
+	// IPv6Addresses must not contain scoped addressing zones.
+	// Zone identifiers are local to an endpoint and are not part of the wire format.
+	IPv6Addresses []netip.Addr
 	// AuthenticationDomainName is the fully qualified domain name of the
 	// nameserver. It must be in DNS presentation format using IDNA A-labels;
 	// U-labels are rejected. It may be empty only when the nameserver supports
@@ -93,6 +95,9 @@ func (c DNSConfiguration) validate() error {
 		for _, addr := range nameserver.IPv6Addresses {
 			if !addr.Is6() || addr.Is4In6() {
 				return fmt.Errorf("non-IPv6 address in IPv6 address list: %s", addr)
+			}
+			if addr.Zone() != "" {
+				return fmt.Errorf("IPv6 address with zone in IPv6 address list: %s", addr)
 			}
 		}
 	}

--- a/dns.go
+++ b/dns.go
@@ -50,6 +50,7 @@ type DNSConfiguration struct {
 
 var dnsNameProfile = idna.New(
 	idna.MapForLookup(),
+	idna.StrictDomainName(false),
 	idna.BidiRule(),
 	idna.VerifyDNSLength(true),
 )
@@ -66,6 +67,7 @@ func validateDomainName(name string, allowEmpty bool) error {
 			return errors.New("must use IDNA A-label form")
 		}
 	}
+	name = strings.TrimSuffix(name, ".")
 	ascii, err := dnsNameProfile.ToASCII(name)
 	if err != nil {
 		return fmt.Errorf("must be a valid IDNA A-label: %w", err)

--- a/dns.go
+++ b/dns.go
@@ -87,6 +87,9 @@ func (c DNSConfiguration) validate() error {
 		if err := validateDomainName(nameserver.AuthenticationDomainName, true); err != nil {
 			return fmt.Errorf("invalid authentication domain name: %w", err)
 		}
+		if nameserver.AuthenticationDomainName == "" && len(nameserver.IPv4Addresses)+len(nameserver.IPv6Addresses) == 0 {
+			return errors.New("nameserver must have an address when authentication domain name is empty")
+		}
 		for _, addr := range nameserver.IPv4Addresses {
 			if !addr.Is4() {
 				return fmt.Errorf("non-IPv4 address in IPv4 address list: %s", addr)

--- a/dns_test.go
+++ b/dns_test.go
@@ -36,6 +36,18 @@ func TestDNSConfigurationDomainValidation(t *testing.T) {
 			},
 		},
 		{
+			name: "underscore label",
+			configuration: DNSConfiguration{
+				SearchDomains: []string{"_msdcs.corp.example"},
+			},
+		},
+		{
+			name: "trailing root dot",
+			configuration: DNSConfiguration{
+				SearchDomains: []string{"example.com."},
+			},
+		},
+		{
 			name: "authentication U-label",
 			configuration: DNSConfiguration{Nameservers: []DNSNameserver{{
 				ServicePriority:          1,
@@ -68,6 +80,13 @@ func TestDNSConfigurationDomainValidation(t *testing.T) {
 			name: "invalid A-label",
 			configuration: DNSConfiguration{
 				SearchDomains: []string{"xn--.example"},
+			},
+			err: "invalid search domain name: must be a valid IDNA A-label",
+		},
+		{
+			name: "leading hyphen",
+			configuration: DNSConfiguration{
+				SearchDomains: []string{"-resolver.example"},
 			},
 			err: "invalid search domain name: must be a valid IDNA A-label",
 		},

--- a/dns_test.go
+++ b/dns_test.go
@@ -1,0 +1,94 @@
+package connectip
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDNSConfigurationDomainValidation(t *testing.T) {
+	tests := []struct {
+		name          string
+		configuration DNSConfiguration
+		err           string
+	}{
+		{
+			name: "A-labels",
+			configuration: DNSConfiguration{
+				Nameservers: []DNSNameserver{{
+					ServicePriority:          1,
+					AuthenticationDomainName: "xn--bcher-kva.example",
+				}},
+				InternalDomains: []string{"xn--bcher-kva.internal.example"},
+				SearchDomains:   []string{"XN--BCHER-KVA.example"},
+			},
+		},
+		{
+			name: "empty authentication and internal domains",
+			configuration: DNSConfiguration{
+				Nameservers:     []DNSNameserver{{ServicePriority: 1}},
+				InternalDomains: []string{""},
+			},
+		},
+		{
+			name: "authentication U-label",
+			configuration: DNSConfiguration{Nameservers: []DNSNameserver{{
+				ServicePriority:          1,
+				AuthenticationDomainName: "bücher.example",
+			}}},
+			err: "invalid authentication domain name: must use IDNA A-label form",
+		},
+		{
+			name: "internal U-label",
+			configuration: DNSConfiguration{
+				Nameservers:     []DNSNameserver{{ServicePriority: 1}},
+				InternalDomains: []string{"bücher.example"},
+			},
+			err: "invalid internal domain name: must use IDNA A-label form",
+		},
+		{
+			name: "search U-label",
+			configuration: DNSConfiguration{
+				Nameservers:   []DNSNameserver{{ServicePriority: 1}},
+				SearchDomains: []string{"bücher.example"},
+			},
+			err: "invalid search domain name: must use IDNA A-label form",
+		},
+		{
+			name: "empty search domain",
+			configuration: DNSConfiguration{
+				Nameservers:   []DNSNameserver{{ServicePriority: 1}},
+				SearchDomains: []string{""},
+			},
+			err: "invalid search domain name: must not be empty",
+		},
+		{
+			name: "invalid A-label",
+			configuration: DNSConfiguration{
+				Nameservers:   []DNSNameserver{{ServicePriority: 1}},
+				SearchDomains: []string{"xn--.example"},
+			},
+			err: "invalid search domain name: must be a valid IDNA A-label",
+		},
+		{
+			name: "label too long",
+			configuration: DNSConfiguration{
+				Nameservers:   []DNSNameserver{{ServicePriority: 1}},
+				SearchDomains: []string{strings.Repeat("a", 64) + ".example"},
+			},
+			err: "invalid search domain name: must be a valid IDNA A-label",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.configuration.validate()
+			if test.err == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, test.err)
+		})
+	}
+}

--- a/dns_test.go
+++ b/dns_test.go
@@ -1,6 +1,7 @@
 package connectip
 
 import (
+	"net/netip"
 	"strings"
 	"testing"
 
@@ -91,4 +92,22 @@ func TestDNSConfigurationDomainValidation(t *testing.T) {
 			require.ErrorContains(t, err, test.err)
 		})
 	}
+}
+
+func TestDNSConfigurationIPv6ZoneValidation(t *testing.T) {
+	t.Run("link-local address without zone", func(t *testing.T) {
+		configuration := DNSConfiguration{Nameservers: []DNSNameserver{{
+			ServicePriority: 1,
+			IPv6Addresses:   []netip.Addr{netip.MustParseAddr("fe80::1")},
+		}}}
+		require.NoError(t, configuration.validate())
+	})
+
+	t.Run("link-local address with zone", func(t *testing.T) {
+		configuration := DNSConfiguration{Nameservers: []DNSNameserver{{
+			ServicePriority: 1,
+			IPv6Addresses:   []netip.Addr{netip.MustParseAddr("fe80::1%eth0")},
+		}}}
+		require.ErrorContains(t, configuration.validate(), "IPv6 address with zone")
+	})
 }

--- a/dns_test.go
+++ b/dns_test.go
@@ -28,7 +28,10 @@ func TestDNSConfigurationDomainValidation(t *testing.T) {
 		{
 			name: "empty authentication and internal domains",
 			configuration: DNSConfiguration{
-				Nameservers:     []DNSNameserver{{ServicePriority: 1}},
+				Nameservers: []DNSNameserver{{
+					ServicePriority: 1,
+					IPv4Addresses:   []netip.Addr{netip.MustParseAddr("192.0.2.53")},
+				}},
 				InternalDomains: []string{""},
 			},
 		},
@@ -43,7 +46,6 @@ func TestDNSConfigurationDomainValidation(t *testing.T) {
 		{
 			name: "internal U-label",
 			configuration: DNSConfiguration{
-				Nameservers:     []DNSNameserver{{ServicePriority: 1}},
 				InternalDomains: []string{"bücher.example"},
 			},
 			err: "invalid internal domain name: must use IDNA A-label form",
@@ -51,7 +53,6 @@ func TestDNSConfigurationDomainValidation(t *testing.T) {
 		{
 			name: "search U-label",
 			configuration: DNSConfiguration{
-				Nameservers:   []DNSNameserver{{ServicePriority: 1}},
 				SearchDomains: []string{"bücher.example"},
 			},
 			err: "invalid search domain name: must use IDNA A-label form",
@@ -59,7 +60,6 @@ func TestDNSConfigurationDomainValidation(t *testing.T) {
 		{
 			name: "empty search domain",
 			configuration: DNSConfiguration{
-				Nameservers:   []DNSNameserver{{ServicePriority: 1}},
 				SearchDomains: []string{""},
 			},
 			err: "invalid search domain name: must not be empty",
@@ -67,7 +67,6 @@ func TestDNSConfigurationDomainValidation(t *testing.T) {
 		{
 			name: "invalid A-label",
 			configuration: DNSConfiguration{
-				Nameservers:   []DNSNameserver{{ServicePriority: 1}},
 				SearchDomains: []string{"xn--.example"},
 			},
 			err: "invalid search domain name: must be a valid IDNA A-label",
@@ -75,7 +74,6 @@ func TestDNSConfigurationDomainValidation(t *testing.T) {
 		{
 			name: "label too long",
 			configuration: DNSConfiguration{
-				Nameservers:   []DNSNameserver{{ServicePriority: 1}},
 				SearchDomains: []string{strings.Repeat("a", 64) + ".example"},
 			},
 			err: "invalid search domain name: must be a valid IDNA A-label",
@@ -92,6 +90,29 @@ func TestDNSConfigurationDomainValidation(t *testing.T) {
 			require.ErrorContains(t, err, test.err)
 		})
 	}
+}
+
+func TestDNSConfigurationNameserverAddressValidation(t *testing.T) {
+	t.Run("no address", func(t *testing.T) {
+		configuration := DNSConfiguration{Nameservers: []DNSNameserver{{ServicePriority: 1}}}
+		require.ErrorContains(t, configuration.validate(), "nameserver must have an address")
+	})
+
+	t.Run("IPv4 address", func(t *testing.T) {
+		configuration := DNSConfiguration{Nameservers: []DNSNameserver{{
+			ServicePriority: 1,
+			IPv4Addresses:   []netip.Addr{netip.MustParseAddr("192.0.2.53")},
+		}}}
+		require.NoError(t, configuration.validate())
+	})
+
+	t.Run("IPv6 address", func(t *testing.T) {
+		configuration := DNSConfiguration{Nameservers: []DNSNameserver{{
+			ServicePriority: 1,
+			IPv6Addresses:   []netip.Addr{netip.MustParseAddr("2001:db8::53")},
+		}}}
+		require.NoError(t, configuration.validate())
+	})
 }
 
 func TestDNSConfigurationIPv6ZoneValidation(t *testing.T) {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `DNS_ASSIGN` and `PREF64` capsule support for CONNECT-IP
> - Implements draft-ietf-masque-connect-ip-dns-06: adds `DNS_ASSIGN` and `PREF64` capsule types with parsers and serializers in [capsule.go](https://github.com/quic-go/connect-ip-go/pull/67/files#diff-fcb26645ce598638fca6816e1387f7465294a2b2becbbeec6fb2128e303ab5e6)
> - Adds `DNSConfiguration` and `DNSNameserver` data models in [dns.go](https://github.com/quic-go/connect-ip-go/pull/67/files#diff-cb1b8a01bbc5f64cf06dce0e3f8021ad8289078b402dc620afa04780484d7cd5) with IDNA domain validation, address-family checks, and IPv6-zone rejection
> - Adds `Conn.SendDNSConfiguration`/`ReceiveDNSConfiguration` and `Conn.SendPREF64Configuration`/`ReceivePREF64Configuration` to [conn.go](https://github.com/quic-go/connect-ip-go/pull/67/files#diff-4f427d2b022907c552328e63f137561f6de92396d7a6e8f6c2ea1bcf0db52654), dispatching incoming capsules through the existing capsule loop with latest-value buffering
> - DNS_ASSIGN payloads are capped at 32 KiB; PREF64 parsing enforces a maximum of 256 prefixes, six allowed prefix lengths, and rejects IPv4-mapped or non-zero-host-bit prefixes
> - Behavioral Change: incoming `DNS_ASSIGN` or `PREF64` capsules with invalid payloads now terminate stream handling, matching the behavior of existing capsule types
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #67 opened
>
> - Removed validation requiring NAT64 prefixes to have all lower bits outside the prefix length set to zero [5a34334]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac0a7dc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DNS configuration support for CONNECT-IP, including nameservers, domains, addresses, and service parameters.
  * Added PREF64/NAT64 prefix configuration support.
  * Added APIs for sending and receiving DNS and PREF64 configuration updates.
  * Increased the supported PREF64 prefix limit to 256.
* **Bug Fixes**
  * Added validation for DNS domains, address families, service priorities, parameters, capsule sizes, and NAT64 prefixes.
  * Improved handling of incomplete or invalid configuration data.
* **Documentation**
  * Updated the README to document support for CONNECT-IP DNS specification draft -06.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->