### PR TITLE
ci: run tests with GOWORK=off

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -12,6 +12,10 @@ jobs:
         go: [ "1.26.x", "1.27.x" ]
     runs-on: ${{ fromJSON(vars[format('UNIT_RUNNER_{0}', matrix.os)] || format('"{0}-latest"', matrix.os)) }}
     name: Unit tests (${{ matrix.os}}, Go ${{ matrix.go }})
+    env:
+      # Test the module as downstream users consume it, without dependency
+      # versions selected from integration/go.mod by the workspace.
+      GOWORK: "off"
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7


### PR DESCRIPTION
Otherwise, the dependencies defined in the integration tests go.mod file might have an effect on the dependencies used for testing.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set `GOWORK=off` for the `unit` CI job
> Adds a top-level `env` block to the `unit` job in [.github/workflows/unit.yml](https://github.com/quic-go/connect-ip-go/pull/69/files#diff-e17ac7ab478a18e9dac875e191cc3e0d754fab62eddddfb05d4619495be927d9) so all steps run with `GOWORK=off`. This makes `go test` ignore any local `go.work` workspace and resolve modules the same way downstream users do.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e653de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->