### PR TITLE
account for the memory consumed by the DNS_ASSIGN capsule

### DIFF
--- a/capsule.go
+++ b/capsule.go
@@ -276,43 +276,66 @@ type dnsAssignCapsule struct {
 	DNSConfigurations []DNSConfiguration
 }
 
-// This limits the wire size, not memory use. Parsing can amplify memory use by
-// roughly 50x, and the limit is chosen accordingly.
-const maxDNSAssignCapsuleSize = 32 << 10
+const (
+	maxDNSAssignMemory = 8 << 20 // 8 MiB
+	// dnsValueOverhead is an approximate per-value allocation overhead used for
+	// DoS protection. Variable-sized data is accounted separately.
+	dnsValueOverhead = 32
+)
 
-func parseCounted[T any](r http3.CapsuleReader, parse func(http3.CapsuleReader) (T, error)) ([]T, error) {
+var errDNSAssignMemoryLimit = fmt.Errorf("DNS_ASSIGN exceeds the %d bytes memory limit", maxDNSAssignMemory)
+
+// parseCounted passes the remaining memory budget to parse. parse returns the
+// budget after parsing the value, and parseCounted subtracts dnsValueOverhead
+// before appending it.
+func parseCounted[T any](
+	r http3.CapsuleReader,
+	remainingMemory uint64,
+	parse func(r http3.CapsuleReader, remainingMemory uint64) (value T, remainingMemoryAfterParsing uint64, err error),
+) (values []T, remainingMemoryAfterParsing uint64, err error) {
 	count, err := quicvarint.Read(r)
 	if err != nil {
-		return nil, err
+		return nil, remainingMemory, err
 	}
-	var values []T
+	if count == 0 {
+		return nil, remainingMemory, nil
+	}
+	// cap the initial allocation to avoid allocating too much memory from the count alone
+	values = make([]T, 0, min(count, 4096))
 	for range count {
-		value, err := parse(r)
-		if err != nil {
-			return nil, err
+		value, remainingMemoryAfterValue, parseErr := parse(r, remainingMemory)
+		if parseErr != nil {
+			return nil, remainingMemory, parseErr
 		}
+		remainingMemory = remainingMemoryAfterValue
+		if dnsValueOverhead > remainingMemory {
+			return nil, remainingMemory, errDNSAssignMemoryLimit
+		}
+		remainingMemory -= dnsValueOverhead
 		values = append(values, value)
 	}
-	return values, nil
+	return values, remainingMemory, nil
 }
 
 func parseDNSAssignCapsule(r http3.CapsuleReader) (*dnsAssignCapsule, error) {
-	if r.Remaining() > maxDNSAssignCapsuleSize {
-		return nil, fmt.Errorf("DNS_ASSIGN capsule too large: %d bytes (maximum %d)", r.Remaining(), maxDNSAssignCapsuleSize)
-	}
+	remainingMemory := uint64(maxDNSAssignMemory)
 	var configurations []DNSConfiguration
 	for r.Remaining() > 0 {
-		nameservers, err := parseCounted(r, parseDNSNameserver)
+		var nameservers []DNSNameserver
+		var err error
+		nameservers, remainingMemory, err = parseCounted(r, remainingMemory, parseDNSNameserver)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("parsing nameservers: %w", err)
 		}
-		internalDomains, err := parseCounted(r, parseDomain)
+		var internalDomains []string
+		internalDomains, remainingMemory, err = parseCounted(r, remainingMemory, parseDomain)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("parsing internal domains: %w", err)
 		}
-		searchDomains, err := parseCounted(r, parseDomain)
+		var searchDomains []string
+		searchDomains, remainingMemory, err = parseCounted(r, remainingMemory, parseDomain)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("parsing search domains: %w", err)
 		}
 		configuration := DNSConfiguration{
 			Nameservers:     nameservers,
@@ -322,89 +345,96 @@ func parseDNSAssignCapsule(r http3.CapsuleReader) (*dnsAssignCapsule, error) {
 		if err := configuration.validate(); err != nil {
 			return nil, fmt.Errorf("invalid DNS configuration: %w", err)
 		}
+		if dnsValueOverhead > remainingMemory {
+			return nil, fmt.Errorf("parsing DNS_ASSIGN configuration %d: %w", len(configurations)+1, errDNSAssignMemoryLimit)
+		}
+		remainingMemory -= dnsValueOverhead
 		configurations = append(configurations, configuration)
 	}
 	return &dnsAssignCapsule{DNSConfigurations: configurations}, nil
 }
 
-func parseDNSNameserver(r http3.CapsuleReader) (DNSNameserver, error) {
+func parseDNSNameserver(r http3.CapsuleReader, remainingMemory uint64) (DNSNameserver, uint64, error) {
 	var priorityBytes [2]byte
 	if _, err := io.ReadFull(r, priorityBytes[:]); err != nil {
-		return DNSNameserver{}, err
+		return DNSNameserver{}, remainingMemory, err
 	}
 	servicePriority := binary.BigEndian.Uint16(priorityBytes[:])
-	ipv4Count, err := quicvarint.Read(r)
-	if err != nil {
-		return DNSNameserver{}, err
-	}
-	var ipv4Addresses []netip.Addr
-	for range ipv4Count {
+	ipv4Addresses, remainingMemory, err := parseCounted(r, remainingMemory, func(r http3.CapsuleReader, remainingMemory uint64) (netip.Addr, uint64, error) {
 		var addr [4]byte
 		if _, err := io.ReadFull(r, addr[:]); err != nil {
-			return DNSNameserver{}, err
+			return netip.Addr{}, remainingMemory, err
 		}
-		ipv4Addresses = append(ipv4Addresses, netip.AddrFrom4(addr))
+		return netip.AddrFrom4(addr), remainingMemory, nil
+	})
+	if err != nil {
+		return DNSNameserver{}, remainingMemory, fmt.Errorf("parsing IPv4 addresses: %w", err)
 	}
 
-	ipv6Count, err := quicvarint.Read(r)
-	if err != nil {
-		return DNSNameserver{}, err
-	}
-	var ipv6Addresses []netip.Addr
-	for range ipv6Count {
+	ipv6Addresses, remainingMemory, err := parseCounted(r, remainingMemory, func(r http3.CapsuleReader, remainingMemory uint64) (netip.Addr, uint64, error) {
 		var addr [16]byte
 		if _, err := io.ReadFull(r, addr[:]); err != nil {
-			return DNSNameserver{}, err
+			return netip.Addr{}, remainingMemory, err
 		}
-		ipv6Addresses = append(ipv6Addresses, netip.AddrFrom16(addr))
+		return netip.AddrFrom16(addr), remainingMemory, nil
+	})
+	if err != nil {
+		return DNSNameserver{}, remainingMemory, fmt.Errorf("parsing IPv6 addresses: %w", err)
 	}
 
-	authenticationDomainName, err := parseDomain(r)
+	authenticationDomainName, remainingMemory, err := parseDomain(r, remainingMemory)
 	if err != nil {
-		return DNSNameserver{}, err
+		return DNSNameserver{}, remainingMemory, fmt.Errorf("parsing authentication domain: %w", err)
 	}
 	paramsLen, err := quicvarint.Read(r)
 	if err != nil {
-		return DNSNameserver{}, err
+		return DNSNameserver{}, remainingMemory, err
 	}
 	if paramsLen > maxServiceParametersLen {
-		return DNSNameserver{}, fmt.Errorf("service parameters too long: %d bytes", paramsLen)
+		return DNSNameserver{}, remainingMemory, fmt.Errorf("service parameters too long: %d bytes", paramsLen)
+	}
+	if paramsLen > remainingMemory {
+		return DNSNameserver{}, remainingMemory, fmt.Errorf("parsing service parameters: %w", errDNSAssignMemoryLimit)
 	}
 	if paramsLen > uint64(r.Remaining()) {
-		return DNSNameserver{}, io.ErrUnexpectedEOF
+		return DNSNameserver{}, remainingMemory, io.ErrUnexpectedEOF
 	}
 	var serviceParameters []byte
 	if paramsLen > 0 {
 		serviceParameters = make([]byte, int(paramsLen))
 		if _, err := io.ReadFull(r, serviceParameters); err != nil {
-			return DNSNameserver{}, err
+			return DNSNameserver{}, remainingMemory, err
 		}
 	}
+	remainingMemory -= paramsLen
 	return DNSNameserver{
 		ServicePriority:          servicePriority,
 		IPv4Addresses:            ipv4Addresses,
 		IPv6Addresses:            ipv6Addresses,
 		AuthenticationDomainName: authenticationDomainName,
 		ServiceParameters:        serviceParameters,
-	}, nil
+	}, remainingMemory, nil
 }
 
-func parseDomain(r http3.CapsuleReader) (string, error) {
+func parseDomain(r http3.CapsuleReader, remainingMemory uint64) (string, uint64, error) {
 	l, err := quicvarint.Read(r)
 	if err != nil {
-		return "", err
+		return "", remainingMemory, err
 	}
 	if l > maxDomainNameLen {
-		return "", fmt.Errorf("domain name too long: %d bytes", l)
+		return "", remainingMemory, fmt.Errorf("domain name too long: %d bytes", l)
 	}
 	if l == 0 {
-		return "", nil
+		return "", remainingMemory, nil
 	}
-	b := make([]byte, int(l))
-	if _, err := io.ReadFull(r, b); err != nil {
-		return "", err
+	if l > remainingMemory {
+		return "", remainingMemory, errDNSAssignMemoryLimit
 	}
-	return string(b), nil
+	var b [maxDomainNameLen]byte
+	if _, err := io.ReadFull(r, b[:l]); err != nil {
+		return "", remainingMemory, err
+	}
+	return string(b[:l]), remainingMemory - l, nil
 }
 
 func (c *dnsAssignCapsule) append(b []byte) []byte {

--- a/capsule_test.go
+++ b/capsule_test.go
@@ -388,13 +388,6 @@ func TestWriteDNSAssignCapsule(t *testing.T) {
 }
 
 func TestParseDNSAssignCapsuleInvalid(t *testing.T) {
-	t.Run("capsule size limit", func(t *testing.T) {
-		payload := make([]byte, maxDNSAssignCapsuleSize+1)
-
-		_, err := parseDNSAssignCapsule(newCapsuleReader(t, capsuleTypeDNSAssign, payload))
-		require.ErrorContains(t, err, "DNS_ASSIGN capsule too large")
-	})
-
 	t.Run("zero service priority", func(t *testing.T) {
 		payload := quicvarint.Append(nil, 1)
 		payload = append(payload, 0, 0)
@@ -426,6 +419,33 @@ func TestParseDNSAssignCapsuleInvalid(t *testing.T) {
 
 		_, err := parseDNSAssignCapsule(newCapsuleReader(t, capsuleTypeDNSAssign, payload))
 		require.ErrorContains(t, err, "domain name too long")
+	})
+
+	t.Run("domain memory limit", func(t *testing.T) {
+		payload := quicvarint.Append(nil, 2)
+		payload = appendDomain(payload, "")
+		payload = appendDomain(payload, "")
+
+		_, _, err := parseCounted(newCapsuleReader(t, capsuleTypeDNSAssign, payload), dnsValueOverhead, parseDomain)
+		require.ErrorIs(t, err, errDNSAssignMemoryLimit)
+	})
+
+	t.Run("domain name memory limit", func(t *testing.T) {
+		_, _, err := parseDomain(newCapsuleReader(t, capsuleTypeDNSAssign, appendDomain(nil, "example")), 0)
+		require.ErrorIs(t, err, errDNSAssignMemoryLimit)
+	})
+
+	t.Run("configuration memory limit", func(t *testing.T) {
+		var payload []byte
+		for range maxDNSAssignMemory/dnsValueOverhead + 1 {
+			payload = quicvarint.Append(payload, 0) // Nameserver Count
+			payload = quicvarint.Append(payload, 0) // Internal Domain Count
+			payload = quicvarint.Append(payload, 0) // Search Domain Count
+		}
+
+		_, err := parseDNSAssignCapsule(newCapsuleReader(t, capsuleTypeDNSAssign, payload))
+		require.ErrorIs(t, err, errDNSAssignMemoryLimit)
+		require.ErrorContains(t, err, "parsing DNS_ASSIGN configuration")
 	})
 
 	t.Run("domain must use A-label form", func(t *testing.T) {
@@ -491,6 +511,18 @@ func TestParseDNSAssignCapsuleInvalid(t *testing.T) {
 			_, err := parseDNSAssignCapsule(r)
 			return err
 		})
+	})
+
+	t.Run("service parameters memory limit", func(t *testing.T) {
+		payload := binary.BigEndian.AppendUint16(nil, 1)
+		payload = quicvarint.Append(payload, 0) // IPv4 Address Count
+		payload = quicvarint.Append(payload, 0) // IPv6 Address Count
+		payload = appendDomain(payload, "")
+		payload = quicvarint.Append(payload, 1)
+		payload = append(payload, 0)
+
+		_, _, err := parseDNSNameserver(newCapsuleReader(t, capsuleTypeDNSAssign, payload), 0)
+		require.ErrorIs(t, err, errDNSAssignMemoryLimit)
 	})
 }
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Enforce 8 MiB memory budget on `parseDNSAssignCapsule` parsing
- Adds a global `maxDNSAssignMemory` (8 MiB) budget and `errDNSAssignMemoryLimit` error; every parsed value deducts `dnsValueOverhead` from the remaining budget, and parsing fails early on exhaustion
- Refactors `parseCounted` to thread a `remainingMemory` budget through its parse callback, cap initial slice capacity at 4096, and return the updated budget; updates `parseDNSNameserver`, `parseDomain`, and `parseDNSAssignCapsule` to propagate this budget across nameservers, domains, and configurations
- Switches `parseDomain` from a length-`l` slice allocation to a fixed `maxDomainNameLen` buffer to avoid per-call heap growth
- Behavioral Change: `parseCounted`, `parseDNSNameserver`, `parseDomain`, and `parseDNSAssignCapsule` now return `errDNSAssignMemoryLimit` (with contextual wrapping) when the 8 MiB budget is exceeded; callers must handle this new error path

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7f84ada. 1 file reviewed, 2 issues evaluated, 1 issue filtered, 1 comment posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>capsule.go — 1 comment posted, 2 evaluated, 1 filtered</summary>

- [line 304](https://github.com/quic-go/connect-ip-go/blob/7f84adaa8a068f93027ad9347b4a53e2c00e4f60/capsule.go#L304): `parseCounted` preallocates capacity for 4,096 values without charging that allocation to `remainingMemory`. A DNS_ASSIGN payload can use a nameserver count of one in each configuration: each returned `[]DNSNameserver` then retains a 4,096-element backing array even though the budget charges only `dnsValueOverhead` (32 bytes) for its sole element. Repeating valid minimal configurations consumes the nominal 8 MiB budget while retaining gigabytes of these arrays, so a peer can exhaust process memory despite the new DoS limit. <b>[ Out of scope (triage) ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for sending and receiving DNS configuration updates.
  - Added support for sending and receiving NAT64 (PREF64) prefix updates.
  - Added validation for DNS domains, nameserver addresses, service parameters, and NAT64 prefixes.
  - Added support for DNS assignment and PREF64 configuration capsules.

- **Bug Fixes**
  - Improved handling of oversized or incomplete configuration data.
  - Added protections against resource exhaustion when processing domains, nameservers, and service parameters.
  - Preserved clear configuration error reporting when memory limits are exceeded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->