### PR TITLE
use a queue for address assignments and route advertisements

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -29,11 +29,6 @@ func (e *CloseError) Is(target error) bool { return target == net.ErrClosed }
 
 type appendable interface{ append([]byte) []byte }
 
-type writeCapsule struct {
-	capsule appendable
-	result  chan error
-}
-
 const (
 	ipProtoICMP   = 1
 	ipProtoICMPv6 = 58
@@ -58,13 +53,14 @@ const minMTU = 1280
 
 // Conn is a connection that proxies IP packets over HTTP/3.
 type Conn struct {
-	str    http3Stream
-	writes chan writeCapsule
+	str         http3Stream
+	writeNotify chan struct{}
 
 	assignedAddressNotify chan struct{}
 	availableRoutesNotify chan struct{}
 
 	mu                sync.Mutex
+	queuedCapsules    []appendable
 	peerAddresses     []netip.Prefix // IP prefixes that we assigned to the peer
 	localRoutes       []IPRoute      // IP routes that we advertised to the peer
 	assignedAddresses []netip.Prefix
@@ -77,7 +73,7 @@ type Conn struct {
 func newProxiedConn(str http3Stream) *Conn {
 	c := &Conn{
 		str:                   str,
-		writes:                make(chan writeCapsule),
+		writeNotify:           make(chan struct{}, 1),
 		assignedAddressNotify: make(chan struct{}, 1),
 		availableRoutesNotify: make(chan struct{}, 1),
 		closeChan:             make(chan struct{}),
@@ -107,52 +103,73 @@ func newProxiedConn(str http3Stream) *Conn {
 	return c
 }
 
-// AdvertiseRoute informs the peer about available routes.
-// This function can be called multiple times, but only the routes from the most recent call will be active.
-// Previous route advertisements are overwritten by each new call to this function.
-func (c *Conn) AdvertiseRoute(ctx context.Context, routes []IPRoute) error {
+// AdvertiseRoute schedules an advertisement of the available routes to the peer.
+// It returns once the advertisement has been queued. A later call can replace a
+// queued advertisement that has not yet been written.
+func (c *Conn) AdvertiseRoute(routes []IPRoute) error {
 	for _, route := range routes {
 		if route.StartIP.Compare(route.EndIP) == 1 {
 			return fmt.Errorf("invalid route advertising start_ip: %s larger than %s", route.StartIP, route.EndIP)
 		}
 	}
+
 	c.mu.Lock()
-	c.localRoutes = slices.Clone(routes)
-	c.mu.Unlock()
-	return c.sendCapsule(ctx, &routeAdvertisementCapsule{IPAddressRanges: routes})
+	defer c.mu.Unlock()
+
+	if c.closeErr != nil {
+		return c.closeErr
+	}
+	routes = slices.Clone(routes)
+	c.localRoutes = routes
+	c.queueCapsule(&routeAdvertisementCapsule{IPAddressRanges: routes})
+	return nil
 }
 
-// AssignAddresses assigned address prefixes to the peer.
-// This function can be called multiple times, but only the addresses from the most recent call will be active.
-// Previous address assignments are overwritten by each new call to this function.
-func (c *Conn) AssignAddresses(ctx context.Context, prefixes []netip.Prefix) error {
-	c.mu.Lock()
-	c.peerAddresses = slices.Clone(prefixes)
-	c.mu.Unlock()
+// AssignAddresses schedules an assignment of address prefixes to the peer.
+// It returns once the assignment has been queued. A later call can replace a
+// queued assignment that has not yet been written.
+func (c *Conn) AssignAddresses(prefixes []netip.Prefix) error {
 	capsule := &addressAssignCapsule{AssignedAddresses: make([]AssignedAddress, 0, len(prefixes))}
 	for _, p := range prefixes {
 		capsule.AssignedAddresses = append(capsule.AssignedAddresses, AssignedAddress{IPPrefix: p})
 	}
-	return c.sendCapsule(ctx, capsule)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.closeErr != nil {
+		return c.closeErr
+	}
+	c.peerAddresses = slices.Clone(prefixes)
+	c.queueCapsule(capsule)
+	return nil
 }
 
-func (c *Conn) sendCapsule(ctx context.Context, capsule appendable) error {
-	res := make(chan error, 1)
-	select {
-	case c.writes <- writeCapsule{
-		capsule: capsule,
-		result:  res,
-	}:
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case err := <-res:
-			return err
+func (c *Conn) queueCapsule(capsule appendable) {
+	// Replace the latest capsule of the same type.
+	// This bounds the memory commitment from queued capsules,
+	// as it limits the size of the queue to the number of capsule types.
+	for i, queued := range c.queuedCapsules {
+		switch queued.(type) {
+		case *addressAssignCapsule:
+			if _, ok := capsule.(*addressAssignCapsule); !ok {
+				continue
+			}
+		case *routeAdvertisementCapsule:
+			if _, ok := capsule.(*routeAdvertisementCapsule); !ok {
+				continue
+			}
+		default:
+			continue
 		}
-	case <-c.closeChan:
-		return c.closeErr
-	case <-ctx.Done():
-		return ctx.Err()
+		c.queuedCapsules = slices.Delete(c.queuedCapsules, i, i+1)
+		break
+	}
+	c.queuedCapsules = append(c.queuedCapsules, capsule)
+
+	select {
+	case c.writeNotify <- struct{}{}:
+	default:
 	}
 }
 
@@ -244,15 +261,26 @@ func (c *Conn) writeToStream() error {
 		select {
 		case <-c.closeChan:
 			return c.closeErr
-		case req, ok := <-c.writes:
-			if !ok {
-				return nil
-			}
-			buf = req.capsule.append(buf[:0])
-			_, err := c.str.Write(buf)
-			req.result <- err
-			if err != nil {
-				return err
+		case <-c.writeNotify:
+			for {
+				c.mu.Lock()
+				if c.closeErr != nil {
+					err := c.closeErr
+					c.mu.Unlock()
+					return err
+				}
+				if len(c.queuedCapsules) == 0 {
+					c.mu.Unlock()
+					break
+				}
+				capsule := c.queuedCapsules[0]
+				c.queuedCapsules = c.queuedCapsules[1:]
+				c.mu.Unlock()
+
+				buf = capsule.append(buf[:0])
+				if _, err := c.str.Write(buf); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -1,6 +1,7 @@
 package connectip
 
 import (
+	"bytes"
 	"context"
 	"net"
 	"net/netip"
@@ -11,6 +12,7 @@ import (
 	"golang.org/x/net/ipv6"
 
 	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
 	"github.com/quic-go/quic-go/quicvarint"
 
 	"github.com/stretchr/testify/require"
@@ -27,6 +29,8 @@ type mockStream struct {
 	reading         []byte
 	toRead          <-chan []byte
 	sendDatagramErr error
+	writeStarted    chan struct{}
+	written         chan<- []byte
 }
 
 var _ http3Stream = &mockStream{}
@@ -40,18 +44,78 @@ func (m *mockStream) Read(p []byte) (int, error) {
 	m.reading = m.reading[n:]
 	return n, nil
 }
-func (m *mockStream) CancelRead(quic.StreamErrorCode)   {}
-func (m *mockStream) Write(p []byte) (n int, err error) { return len(p), nil }
-func (m *mockStream) Close() error                      { return nil }
-func (m *mockStream) CancelWrite(quic.StreamErrorCode)  {}
-func (m *mockStream) Context() context.Context          { return context.Background() }
-func (m *mockStream) SetWriteDeadline(time.Time) error  { return nil }
-func (m *mockStream) SetReadDeadline(time.Time) error   { return nil }
-func (m *mockStream) SetDeadline(time.Time) error       { return nil }
-func (m *mockStream) SendDatagram(data []byte) error    { return m.sendDatagramErr }
+func (m *mockStream) CancelRead(quic.StreamErrorCode) {}
+func (m *mockStream) Write(p []byte) (int, error) {
+	if m.writeStarted != nil {
+		close(m.writeStarted)
+		m.writeStarted = nil
+	}
+	if m.written != nil {
+		m.written <- bytes.Clone(p)
+	}
+	return len(p), nil
+}
+func (m *mockStream) Close() error                     { return nil }
+func (m *mockStream) CancelWrite(quic.StreamErrorCode) {}
+func (m *mockStream) Context() context.Context         { return context.Background() }
+func (m *mockStream) SetWriteDeadline(time.Time) error { return nil }
+func (m *mockStream) SetReadDeadline(time.Time) error  { return nil }
+func (m *mockStream) SetDeadline(time.Time) error      { return nil }
+func (m *mockStream) SendDatagram(data []byte) error   { return m.sendDatagramErr }
 func (m *mockStream) ReceiveDatagram(ctx context.Context) ([]byte, error) {
 	<-ctx.Done()
 	return nil, ctx.Err()
+}
+
+func TestCapsuleWritesAreCoalesced(t *testing.T) {
+	writes := make(chan []byte)
+	writeStarted := make(chan struct{})
+	conn := newProxiedConn(&mockStream{
+		writeStarted: writeStarted,
+		written:      writes,
+	})
+	t.Cleanup(func() { conn.Close() })
+
+	// Block the first write. While it is blocked, the remaining calls stay queued,
+	// and the newer capsule of each type replaces the older one.
+	require.NoError(t, conn.AssignAddresses(nil))
+	select {
+	case <-writeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("capsule write did not start")
+	}
+
+	oldPrefix := netip.MustParsePrefix("192.0.2.1/32")
+	wantPrefix := netip.MustParsePrefix("2001:db8::/64")
+	oldIP := netip.MustParseAddr("192.0.2.1")
+	wantIP := netip.MustParseAddr("2001:db8::1")
+	oldRoute := IPRoute{StartIP: oldIP, EndIP: oldIP}
+	wantRoute := IPRoute{StartIP: wantIP, EndIP: wantIP}
+	require.NoError(t, conn.AssignAddresses([]netip.Prefix{oldPrefix}))
+	require.NoError(t, conn.AdvertiseRoute([]IPRoute{oldRoute}))
+	require.NoError(t, conn.AssignAddresses([]netip.Prefix{wantPrefix}))
+	require.NoError(t, conn.AdvertiseRoute([]IPRoute{wantRoute}))
+
+	var assignedAddresses []AssignedAddress
+	var advertisedRoutes []IPRoute
+	for range 3 {
+		typ, r, err := http3.NewCapsuleParser(bytes.NewReader(<-writes)).Next()
+		require.NoError(t, err)
+		switch typ {
+		case capsuleTypeAddressAssign:
+			capsule, err := parseAddressAssignCapsule(r)
+			require.NoError(t, err)
+			assignedAddresses = append(assignedAddresses, capsule.AssignedAddresses...)
+		case capsuleTypeRouteAdvertisement:
+			capsule, err := parseRouteAdvertisementCapsule(r)
+			require.NoError(t, err)
+			advertisedRoutes = append(advertisedRoutes, capsule.IPAddressRanges...)
+		default:
+			t.Fatalf("unexpected capsule type: %d", typ)
+		}
+	}
+	require.Equal(t, []AssignedAddress{{IPPrefix: wantPrefix}}, assignedAddresses)
+	require.Equal(t, []IPRoute{wantRoute}, advertisedRoutes)
 }
 
 func TestIncomingDatagrams(t *testing.T) {
@@ -98,9 +162,7 @@ func TestIncomingDatagrams(t *testing.T) {
 
 	t.Run("invalid source address", func(t *testing.T) {
 		conn := newProxiedConn(&mockStream{})
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-		defer cancel()
-		require.NoError(t, conn.AssignAddresses(ctx, []netip.Prefix{netip.MustParsePrefix("192.168.0.10/32")}))
+		require.NoError(t, conn.AssignAddresses([]netip.Prefix{netip.MustParsePrefix("192.168.0.10/32")}))
 		hdr := &ipv4.Header{
 			Src:      net.IPv4(192, 168, 0, 11),
 			Dst:      net.IPv4(159, 70, 42, 98),
@@ -117,10 +179,8 @@ func TestIncomingDatagrams(t *testing.T) {
 
 	t.Run("invalid destination address", func(t *testing.T) {
 		conn := newProxiedConn(&mockStream{})
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-		defer cancel()
-		require.NoError(t, conn.AssignAddresses(ctx, []netip.Prefix{netip.MustParsePrefix("192.168.0.10/32")}))
-		require.NoError(t, conn.AdvertiseRoute(ctx, []IPRoute{
+		require.NoError(t, conn.AssignAddresses([]netip.Prefix{netip.MustParsePrefix("192.168.0.10/32")}))
+		require.NoError(t, conn.AdvertiseRoute([]IPRoute{
 			{StartIP: netip.MustParseAddr("10.0.0.0"), EndIP: netip.MustParseAddr("10.1.2.3")},
 		}))
 		hdr := &ipv4.Header{
@@ -145,10 +205,8 @@ func TestIncomingDatagrams(t *testing.T) {
 
 	t.Run("invalid IP protocol", func(t *testing.T) {
 		conn := newProxiedConn(&mockStream{})
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-		defer cancel()
-		require.NoError(t, conn.AssignAddresses(ctx, []netip.Prefix{netip.MustParsePrefix("192.168.0.10/32")}))
-		require.NoError(t, conn.AdvertiseRoute(ctx, []IPRoute{
+		require.NoError(t, conn.AssignAddresses([]netip.Prefix{netip.MustParsePrefix("192.168.0.10/32")}))
+		require.NoError(t, conn.AdvertiseRoute([]IPRoute{
 			{StartIP: netip.MustParseAddr("10.0.0.0"), EndIP: netip.MustParseAddr("10.1.2.3"), IPProtocol: 42},
 		}))
 		hdr := &ipv4.Header{
@@ -226,13 +284,11 @@ func TestSkipUnknownCapsule(t *testing.T) {
 
 func FuzzIncomingDatagram(f *testing.F) {
 	conn := newProxiedConn(&mockStream{})
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	require.NoError(f, conn.AssignAddresses(ctx, []netip.Prefix{
+	require.NoError(f, conn.AssignAddresses([]netip.Prefix{
 		netip.MustParsePrefix("192.168.0.0/16"),
 		netip.MustParsePrefix("2001:db8::0/64"),
 	}))
-	require.NoError(f, conn.AdvertiseRoute(ctx, []IPRoute{
+	require.NoError(f, conn.AdvertiseRoute([]IPRoute{
 		{StartIP: netip.MustParseAddr("10.0.0.0"), EndIP: netip.MustParseAddr("10.1.2.3"), IPProtocol: 42},
 		{StartIP: netip.MustParseAddr("2001:db8:1::"), EndIP: netip.MustParseAddr("2001:db8:1::ffff"), IPProtocol: 42},
 	}))

--- a/integration/proxy/proxy.go
+++ b/integration/proxy/proxy.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -14,7 +13,6 @@ import (
 	"os"
 	"strconv"
 	"syscall"
-	"time"
 
 	"golang.org/x/sys/unix"
 
@@ -212,13 +210,10 @@ func run(bindTo netip.AddrPort, remoteAddr netip.Addr, route netip.Prefix, ipPro
 }
 
 func handleConn(conn *connectip.Conn, addr netip.Addr, route netip.Prefix, ipProtocol uint8) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	if err := conn.AssignAddresses(ctx, []netip.Prefix{netip.PrefixFrom(addr, addr.BitLen())}); err != nil {
+	if err := conn.AssignAddresses([]netip.Prefix{netip.PrefixFrom(addr, addr.BitLen())}); err != nil {
 		return fmt.Errorf("failed to assign addresses: %w", err)
 	}
-	if err := conn.AdvertiseRoute(ctx, []connectip.IPRoute{
+	if err := conn.AdvertiseRoute([]connectip.IPRoute{
 		{StartIP: route.Addr(), EndIP: utils.LastIP(route), IPProtocol: ipProtocol},
 	}); err != nil {
 		return fmt.Errorf("failed to advertise route: %w", err)

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -88,13 +88,13 @@ func TestAddressAssignment(t *testing.T) {
 	defer cancel()
 	pref1 := netip.MustParsePrefix("1.1.1.0/24")
 	pref2 := netip.MustParsePrefix("2001:db8::/64")
-	require.NoError(t, client.AssignAddresses(ctx, []netip.Prefix{pref1, pref2}))
+	require.NoError(t, client.AssignAddresses([]netip.Prefix{pref1, pref2}))
 	routes, err := server.LocalPrefixes(ctx)
 	require.NoError(t, err)
 	require.Equal(t, []netip.Prefix{pref1, pref2}, routes)
 
 	// addresses are replaced once a new capsule is received
-	require.NoError(t, client.AssignAddresses(ctx, []netip.Prefix{}))
+	require.NoError(t, client.AssignAddresses([]netip.Prefix{}))
 	routes, err = server.LocalPrefixes(ctx)
 	require.NoError(t, err)
 	require.Empty(t, routes)
@@ -114,14 +114,14 @@ func TestRouteAdvertisement(t *testing.T) {
 
 	// refuse to advertise invalid routes
 	require.ErrorContains(t,
-		client.AdvertiseRoute(ctx, []IPRoute{
+		client.AdvertiseRoute([]IPRoute{
 			{StartIP: netip.MustParseAddr("1.1.1.2"), EndIP: netip.MustParseAddr("1.1.1.1"), IPProtocol: 42},
 		}),
 		"invalid route advertising start_ip: 1.1.1.2 larger than 1.1.1.1",
 	)
 
 	// advertise some routes and make sure they're received
-	require.NoError(t, client.AdvertiseRoute(ctx, []IPRoute{
+	require.NoError(t, client.AdvertiseRoute([]IPRoute{
 		{StartIP: netip.MustParseAddr("1.1.1.1"), EndIP: netip.MustParseAddr("2.2.2.2"), IPProtocol: 42},
 		{StartIP: netip.MustParseAddr("2001:db8::1"), EndIP: netip.MustParseAddr("2001:db8::100"), IPProtocol: 24},
 	}))
@@ -133,7 +133,7 @@ func TestRouteAdvertisement(t *testing.T) {
 	}, routes)
 
 	// routes are replaced once a new capsule is received
-	require.NoError(t, client.AdvertiseRoute(ctx, []IPRoute{}))
+	require.NoError(t, client.AdvertiseRoute([]IPRoute{}))
 	routes, err = server.Routes(ctx)
 	require.NoError(t, err)
 	require.Empty(t, routes)
@@ -142,10 +142,8 @@ func TestRouteAdvertisement(t *testing.T) {
 func TestTTLs(t *testing.T) {
 	t.Run("IPv4", func(t *testing.T) {
 		client, server := setupConns(t)
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
-		defer cancel()
-		require.NoError(t, server.AssignAddresses(ctx, []netip.Prefix{netip.MustParsePrefix("192.168.1.1/32")}))
-		require.NoError(t, server.AdvertiseRoute(ctx, []IPRoute{
+		require.NoError(t, server.AssignAddresses([]netip.Prefix{netip.MustParsePrefix("192.168.1.1/32")}))
+		require.NoError(t, server.AdvertiseRoute([]IPRoute{
 			{StartIP: netip.MustParseAddr("0.0.0.0"), EndIP: netip.MustParseAddr("255.255.255.255")},
 		}))
 
@@ -190,10 +188,8 @@ func TestTTLs(t *testing.T) {
 
 	t.Run("IPv6", func(t *testing.T) {
 		client, server := setupConns(t)
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
-		defer cancel()
-		require.NoError(t, server.AssignAddresses(ctx, []netip.Prefix{netip.MustParsePrefix("2001:db8::1/128")}))
-		require.NoError(t, server.AdvertiseRoute(ctx, []IPRoute{
+		require.NoError(t, server.AssignAddresses([]netip.Prefix{netip.MustParsePrefix("2001:db8::1/128")}))
+		require.NoError(t, server.AdvertiseRoute([]IPRoute{
 			{StartIP: netip.MustParseAddr("::"), EndIP: netip.MustParseAddr("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")},
 		}))
 
@@ -264,11 +260,11 @@ func TestClosing(t *testing.T) {
 	_, err = client.Routes(context.Background())
 	require.ErrorIs(t, err, net.ErrClosed)
 	require.ErrorIs(t,
-		client.AssignAddresses(context.Background(), []netip.Prefix{netip.MustParsePrefix("1.1.1.0/24")}),
+		client.AssignAddresses([]netip.Prefix{netip.MustParsePrefix("1.1.1.0/24")}),
 		net.ErrClosed,
 	)
 	require.ErrorIs(t,
-		client.AdvertiseRoute(context.Background(), []IPRoute{
+		client.AdvertiseRoute([]IPRoute{
 			{StartIP: netip.MustParseAddr("1.1.1.0"), EndIP: netip.MustParseAddr("1.1.1.1"), IPProtocol: 42},
 		}),
 		net.ErrClosed,


### PR DESCRIPTION
Make AssignAddresses and AdvertiseRoute return after enqueueing their capsules instead of waiting for the stream write. Replace queued capsules of the same type so only the latest state is sent.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Queue and coalesce address assignments and route advertisements in `Conn`
> - `Conn.AssignAddresses` and `Conn.AdvertiseRoute` drop the context parameter and return immediately after enqueueing the capsule.
> - `Conn.queueCapsule` coalesces pending capsules by type, replacing the latest existing capsule of the same type to bound queue size.
> - The writer goroutine in `Conn.writeToStream` listens on a `writeNotify` channel instead of per-request structs, draining and writing queued capsules sequentially.
> - Behavioral Change: `AssignAddresses` and `AdvertiseRoute` no longer block until write completion or return underlying stream write errors synchronously. They only return `net.ErrClosed` if the connection is already closed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 62addf1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * Simplified route advertisement and address assignment calls by removing the context parameter.
  * These operations now return after being queued.

* **Bug Fixes**
  * Improved handling of connection closure and write errors.
  * Prevented outdated route or address updates from being sent when newer updates are queued.

* **Performance**
  * Coalesced pending updates to reduce redundant capsule writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->