### PR TITLE
introduce a Transport and a ClientConn

### DIFF
--- a/client.go
+++ b/client.go
@@ -5,31 +5,40 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 
+	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
-	"github.com/yosida95/uritemplate/v3"
 )
 
-// Dial dials a proxied connection to a target server.
-func Dial(ctx context.Context, conn *http3.ClientConn, template *uritemplate.Template) (*Conn, *http.Response, error) {
-	if len(template.Varnames()) > 0 {
-		return nil, nil, errors.New("connect-ip: IP flow forwarding not supported")
-	}
+// A ClientConn represents a connection to a single proxy server.
+// Multiple proxied connections can be established over a single ClientConn.
+type ClientConn struct {
+	clientConn *http3.ClientConn
+}
 
-	u, err := url.Parse(template.Raw())
-	if err != nil {
-		return nil, nil, fmt.Errorf("connect-ip: failed to parse URI: %w", err)
+// Dial dials a proxied connection over the proxy connection.
+func (c *ClientConn) Dial(req *Request) (*Conn, *http.Response, error) {
+	return c.dial(req, nil)
+}
+
+func (c *ClientConn) dial(req *Request, closeConn func() error) (*Conn, *http.Response, error) {
+	httpReq := req.httpRequest()
+	if httpReq.URL == nil {
+		return nil, nil, errors.New("connect-ip: request URL is nil")
+	}
+	if httpReq.Host == "" && httpReq.URL.Host == "" {
+		return nil, nil, errors.New("connect-ip: request needs a host")
 	}
 
 	select {
-	case <-ctx.Done():
-		return nil, nil, context.Cause(ctx)
-	case <-conn.Context().Done():
-		return nil, nil, context.Cause(conn.Context())
-	case <-conn.ReceivedSettings():
+	case <-httpReq.Context().Done():
+		return nil, nil, context.Cause(httpReq.Context())
+	case <-c.clientConn.Context().Done():
+		return nil, nil, context.Cause(c.clientConn.Context())
+	case <-c.clientConn.ReceivedSettings():
 	}
-	settings := conn.Settings()
+
+	settings := c.clientConn.Settings()
 	if !settings.EnableExtendedConnect {
 		return nil, nil, errors.New("connect-ip: server didn't enable Extended CONNECT")
 	}
@@ -37,17 +46,18 @@ func Dial(ctx context.Context, conn *http3.ClientConn, template *uritemplate.Tem
 		return nil, nil, errors.New("connect-ip: server didn't enable datagrams")
 	}
 
-	rstr, err := conn.OpenRequestStream(ctx)
+	rstr, err := c.clientConn.OpenRequestStream(httpReq.Context())
 	if err != nil {
 		return nil, nil, fmt.Errorf("connect-ip: failed to open request stream: %w", err)
 	}
-	if err := rstr.SendRequestHeader(&http.Request{
-		Method: http.MethodConnect,
-		Proto:  requestProtocol,
-		Host:   u.Host,
-		Header: http.Header{http3.CapsuleProtocolHeader: []string{capsuleProtocolHeaderValue}},
-		URL:    u,
-	}); err != nil {
+	var keepStream bool
+	defer func() {
+		if !keepStream {
+			rstr.CancelRead(quic.StreamErrorCode(http3.ErrCodeNoError))
+			rstr.CancelWrite(quic.StreamErrorCode(http3.ErrCodeNoError))
+		}
+	}()
+	if err := rstr.SendRequestHeader(httpReq); err != nil {
 		return nil, nil, fmt.Errorf("connect-ip: failed to send request: %w", err)
 	}
 	// TODO: optimistically return the connection
@@ -58,5 +68,6 @@ func Dial(ctx context.Context, conn *http3.ClientConn, template *uritemplate.Tem
 	if rsp.StatusCode < 200 || rsp.StatusCode > 299 {
 		return nil, rsp, fmt.Errorf("connect-ip: server responded with %d", rsp.StatusCode)
 	}
-	return newProxiedConn(rstr), rsp, nil
+	keepStream = true
+	return newProxiedConn(rstr, closeConn), rsp, nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -14,9 +14,8 @@ import (
 )
 
 func TestClientInvalidTemplate(t *testing.T) {
-	_, _, err := Dial(
-		context.Background(),
-		nil,
+	_, err := NewRequest(
+		t.Context(),
 		uritemplate.MustNew("https://example.org/.well-known/masque/ip/{target}/{ipproto}/"),
 	)
 	require.ErrorContains(t, err, "connect-ip: IP flow forwarding not supported")
@@ -25,14 +24,11 @@ func TestClientInvalidTemplate(t *testing.T) {
 func TestClientWaitForSettings(t *testing.T) {
 	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
 	require.NoError(t, err)
-	ln, err := quic.Listen(conn, tlsConf, nil)
+	ln, err := quic.Listen(conn, tlsConf, &quic.Config{EnableDatagrams: true})
 	require.NoError(t, err)
 	defer ln.Close()
 
-	tr := &http3.Transport{}
-	defer tr.Close()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	defer cancel()
 	cconn, err := quic.DialAddr(
 		ctx,
@@ -41,19 +37,21 @@ func TestClientWaitForSettings(t *testing.T) {
 		&quic.Config{EnableDatagrams: true},
 	)
 	require.NoError(t, err)
+	defer cconn.CloseWithError(0, "")
+	clientConn, err := new(Transport).NewClientConn(cconn)
+	require.NoError(t, err)
+	req, err := NewRequest(ctx, uritemplate.MustNew("https://example.org/.well-known/masque/ip/"))
+	require.NoError(t, err)
 	// We're connecting to a QUIC, not an HTTP/3 server.
 	// We'll never receive any HTTP/3 settings.
-	_, _, err = Dial(
-		ctx,
-		tr.NewClientConn(cconn),
-		uritemplate.MustNew("https://example.org/.well-known/masque/ip/"),
-	)
+	_, _, err = clientConn.Dial(req)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 func TestClientDatagramCheck(t *testing.T) {
 	s := http3.Server{
 		TLSConfig:       tlsConf,
+		QUICConfig:      &quic.Config{EnableDatagrams: true},
 		EnableDatagrams: false,
 	}
 	ln, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
@@ -61,7 +59,7 @@ func TestClientDatagramCheck(t *testing.T) {
 	go func() { s.Serve(ln) }()
 	defer s.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 	cconn, err := quic.DialAddr(
 		ctx,
@@ -72,15 +70,39 @@ func TestClientDatagramCheck(t *testing.T) {
 	require.NoError(t, err)
 	defer cconn.CloseWithError(0, "")
 
-	// Create a HTTP/3 client and dial the server
-	tr := &http3.Transport{}
-	defer tr.Close()
-
-	// Now use the QUIC connection in the Dial call
-	_, _, err = Dial(
-		context.Background(),
-		tr.NewClientConn(cconn),
-		uritemplate.MustNew("https://example.org/.well-known/masque/ip/"),
-	)
+	clientConn, err := new(Transport).NewClientConn(cconn)
+	require.NoError(t, err)
+	req, err := NewRequest(ctx, uritemplate.MustNew("https://example.org/.well-known/masque/ip/"))
+	require.NoError(t, err)
+	_, _, err = clientConn.Dial(req)
 	require.ErrorContains(t, err, "connect-ip: server didn't enable datagrams")
+}
+
+func TestTransportRequiresDatagrams(t *testing.T) {
+	req, err := NewRequest(t.Context(), uritemplate.MustNew("https://localhost/connect-ip"))
+	require.NoError(t, err)
+	_, _, err = (&Transport{QUICConfig: &quic.Config{}}).Dial(req)
+	require.ErrorContains(t, err, "QUICConfig needs to enable datagrams")
+}
+
+func TestNewClientConnRequiresDatagrams(t *testing.T) {
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	require.NoError(t, err)
+	ln, err := quic.Listen(conn, tlsConf, nil)
+	require.NoError(t, err)
+	defer ln.Close()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	cconn, err := quic.DialAddr(
+		ctx,
+		conn.LocalAddr().String(),
+		&tls.Config{ServerName: "localhost", RootCAs: certPool, NextProtos: []string{http3.NextProtoH3}},
+		&quic.Config{EnableDatagrams: true},
+	)
+	require.NoError(t, err)
+	defer cconn.CloseWithError(0, "")
+
+	_, err = new(Transport).NewClientConn(cconn)
+	require.ErrorContains(t, err, "QUIC connection needs datagram support")
 }

--- a/client_test.go
+++ b/client_test.go
@@ -77,32 +77,3 @@ func TestClientDatagramCheck(t *testing.T) {
 	_, _, err = clientConn.Dial(req)
 	require.ErrorContains(t, err, "connect-ip: server didn't enable datagrams")
 }
-
-func TestTransportRequiresDatagrams(t *testing.T) {
-	req, err := NewRequest(t.Context(), uritemplate.MustNew("https://localhost/connect-ip"))
-	require.NoError(t, err)
-	_, _, err = (&Transport{QUICConfig: &quic.Config{}}).Dial(req)
-	require.ErrorContains(t, err, "QUICConfig needs to enable datagrams")
-}
-
-func TestNewClientConnRequiresDatagrams(t *testing.T) {
-	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
-	require.NoError(t, err)
-	ln, err := quic.Listen(conn, tlsConf, nil)
-	require.NoError(t, err)
-	defer ln.Close()
-
-	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
-	defer cancel()
-	cconn, err := quic.DialAddr(
-		ctx,
-		conn.LocalAddr().String(),
-		&tls.Config{ServerName: "localhost", RootCAs: certPool, NextProtos: []string{http3.NextProtoH3}},
-		&quic.Config{EnableDatagrams: true},
-	)
-	require.NoError(t, err)
-	defer cconn.CloseWithError(0, "")
-
-	_, err = new(Transport).NewClientConn(cconn)
-	require.ErrorContains(t, err, "QUIC connection needs datagram support")
-}

--- a/conn.go
+++ b/conn.go
@@ -54,6 +54,7 @@ const minMTU = 1280
 // Conn is a connection that proxies IP packets over HTTP/3.
 type Conn struct {
 	str         http3Stream
+	closeConn   func() error
 	writeNotify chan struct{}
 
 	assignedAddressNotify chan struct{}
@@ -70,9 +71,10 @@ type Conn struct {
 	closeErr  error
 }
 
-func newProxiedConn(str http3Stream) *Conn {
+func newProxiedConn(str http3Stream, closeConn func() error) *Conn {
 	c := &Conn{
 		str:                   str,
+		closeConn:             closeConn,
 		writeNotify:           make(chan struct{}, 1),
 		assignedAddressNotify: make(chan struct{}, 1),
 		availableRoutesNotify: make(chan struct{}, 1),
@@ -450,9 +452,14 @@ func (c *Conn) Close() error {
 		c.closeErr = &CloseError{Remote: false}
 		close(c.closeChan)
 	}
+	closeConn := c.closeConn
+	c.closeConn = nil
 	c.mu.Unlock()
 	c.str.CancelRead(quic.StreamErrorCode(http3.ErrCodeNoError))
 	err := c.str.Close()
+	if closeConn != nil {
+		return errors.Join(err, closeConn())
+	}
 	return err
 }
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -73,7 +73,7 @@ func TestCapsuleWritesAreCoalesced(t *testing.T) {
 	conn := newProxiedConn(&mockStream{
 		writeStarted: writeStarted,
 		written:      writes,
-	})
+	}, nil)
 	t.Cleanup(func() { conn.Close() })
 
 	// Block the first write. While it is blocked, the remaining calls stay queued,
@@ -120,7 +120,7 @@ func TestCapsuleWritesAreCoalesced(t *testing.T) {
 
 func TestIncomingDatagrams(t *testing.T) {
 	t.Run("empty packets", func(t *testing.T) {
-		conn := newProxiedConn(&mockStream{})
+		conn := newProxiedConn(&mockStream{}, nil)
 		require.ErrorContains(t,
 			conn.handleIncomingProxiedPacket([]byte{}),
 			"connect-ip: empty packet",
@@ -128,7 +128,7 @@ func TestIncomingDatagrams(t *testing.T) {
 	})
 
 	t.Run("invalid IP version", func(t *testing.T) {
-		conn := newProxiedConn(&mockStream{})
+		conn := newProxiedConn(&mockStream{}, nil)
 		data := make([]byte, 20)
 		data[0] = 5 << 4 // IPv5
 		require.ErrorContains(t,
@@ -138,7 +138,7 @@ func TestIncomingDatagrams(t *testing.T) {
 	})
 
 	t.Run("IPv4 packet too short", func(t *testing.T) {
-		conn := newProxiedConn(&mockStream{})
+		conn := newProxiedConn(&mockStream{}, nil)
 		data, err := (&ipv4.Header{
 			Src:      net.IPv4(1, 2, 3, 4),
 			Dst:      net.IPv4(159, 70, 42, 98),
@@ -153,7 +153,7 @@ func TestIncomingDatagrams(t *testing.T) {
 	})
 
 	t.Run("IPv6 packet too short", func(t *testing.T) {
-		conn := newProxiedConn(&mockStream{})
+		conn := newProxiedConn(&mockStream{}, nil)
 		require.ErrorContains(t,
 			conn.handleIncomingProxiedPacket(ipv6Header[:ipv6.HeaderLen-1]),
 			"connect-ip: malformed datagram: too short",
@@ -161,7 +161,7 @@ func TestIncomingDatagrams(t *testing.T) {
 	})
 
 	t.Run("invalid source address", func(t *testing.T) {
-		conn := newProxiedConn(&mockStream{})
+		conn := newProxiedConn(&mockStream{}, nil)
 		require.NoError(t, conn.AssignAddresses([]netip.Prefix{netip.MustParsePrefix("192.168.0.10/32")}))
 		hdr := &ipv4.Header{
 			Src:      net.IPv4(192, 168, 0, 11),
@@ -178,7 +178,7 @@ func TestIncomingDatagrams(t *testing.T) {
 	})
 
 	t.Run("invalid destination address", func(t *testing.T) {
-		conn := newProxiedConn(&mockStream{})
+		conn := newProxiedConn(&mockStream{}, nil)
 		require.NoError(t, conn.AssignAddresses([]netip.Prefix{netip.MustParsePrefix("192.168.0.10/32")}))
 		require.NoError(t, conn.AdvertiseRoute([]IPRoute{
 			{StartIP: netip.MustParseAddr("10.0.0.0"), EndIP: netip.MustParseAddr("10.1.2.3")},
@@ -204,7 +204,7 @@ func TestIncomingDatagrams(t *testing.T) {
 	})
 
 	t.Run("invalid IP protocol", func(t *testing.T) {
-		conn := newProxiedConn(&mockStream{})
+		conn := newProxiedConn(&mockStream{}, nil)
 		require.NoError(t, conn.AssignAddresses([]netip.Prefix{netip.MustParsePrefix("192.168.0.10/32")}))
 		require.NoError(t, conn.AdvertiseRoute([]IPRoute{
 			{StartIP: netip.MustParseAddr("10.0.0.0"), EndIP: netip.MustParseAddr("10.1.2.3"), IPProtocol: 42},
@@ -237,7 +237,7 @@ func TestIncomingDatagrams(t *testing.T) {
 
 	t.Run("packet from assigned address", func(t *testing.T) {
 		readChan := make(chan []byte, 1)
-		conn := newProxiedConn(&mockStream{toRead: readChan})
+		conn := newProxiedConn(&mockStream{toRead: readChan}, nil)
 
 		hdr := &ipv4.Header{
 			Src:      net.IPv4(159, 70, 42, 98),
@@ -265,7 +265,7 @@ func TestIncomingDatagrams(t *testing.T) {
 
 func TestSkipUnknownCapsule(t *testing.T) {
 	readChan := make(chan []byte, 1)
-	conn := newProxiedConn(&mockStream{toRead: readChan})
+	conn := newProxiedConn(&mockStream{toRead: readChan}, nil)
 
 	data := quicvarint.Append(nil, 42)
 	data = quicvarint.Append(data, 3)
@@ -283,7 +283,7 @@ func TestSkipUnknownCapsule(t *testing.T) {
 }
 
 func FuzzIncomingDatagram(f *testing.F) {
-	conn := newProxiedConn(&mockStream{})
+	conn := newProxiedConn(&mockStream{}, nil)
 	require.NoError(f, conn.AssignAddresses([]netip.Prefix{
 		netip.MustParsePrefix("192.168.0.0/16"),
 		netip.MustParsePrefix("2001:db8::0/64"),
@@ -311,7 +311,7 @@ func FuzzIncomingDatagram(f *testing.F) {
 
 func TestSendingDatagrams(t *testing.T) {
 	t.Run("invalid IP version", func(t *testing.T) {
-		conn := newProxiedConn(&mockStream{})
+		conn := newProxiedConn(&mockStream{}, nil)
 		data := make([]byte, 20)
 		data[0] = 5 << 4 // IPv5
 		_, err := conn.composeDatagram(data)
@@ -319,7 +319,7 @@ func TestSendingDatagrams(t *testing.T) {
 	})
 
 	t.Run("IPv4 packet too short", func(t *testing.T) {
-		conn := newProxiedConn(&mockStream{})
+		conn := newProxiedConn(&mockStream{}, nil)
 		data, err := (&ipv4.Header{
 			Src:      net.IPv4(1, 2, 3, 4),
 			Dst:      net.IPv4(159, 70, 42, 98),
@@ -332,7 +332,7 @@ func TestSendingDatagrams(t *testing.T) {
 	})
 
 	t.Run("IPv6 packet too short", func(t *testing.T) {
-		conn := newProxiedConn(&mockStream{})
+		conn := newProxiedConn(&mockStream{}, nil)
 		_, err := conn.composeDatagram(ipv6Header[:ipv6.HeaderLen-1])
 		require.ErrorContains(t, err, "connect-ip: IPv6 packet too short")
 	})
@@ -340,7 +340,7 @@ func TestSendingDatagrams(t *testing.T) {
 
 func TestSendLargeDatagrams(t *testing.T) {
 	str := &mockStream{sendDatagramErr: &quic.DatagramTooLargeError{}}
-	conn := newProxiedConn(str)
+	conn := newProxiedConn(str, nil)
 	data, err := (&ipv4.Header{
 		Version:  4,
 		Len:      20,

--- a/integration/client/client.go
+++ b/integration/client/client.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net"
 	"net/http"
 	"net/netip"
 	"os"
@@ -119,35 +118,27 @@ func establishConn(proxyAddr netip.AddrPort, keyLog io.Writer) (*water.Interface
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	udpConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(0, 0, 0, 0)})
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to listen on UDP: %w", err)
-	}
-
-	conn, err := quic.Dial(
-		ctx,
-		udpConn,
-		&net.UDPAddr{IP: proxyAddr.Addr().AsSlice(), Port: int(proxyAddr.Port())},
-		&tls.Config{
+	tr := &connectip.Transport{
+		TLSClientConfig: &tls.Config{
 			ServerName:         "proxy",
 			InsecureSkipVerify: true,
 			NextProtos:         []string{http3.NextProtoH3},
 			KeyLogWriter:       keyLog,
 		},
-		&quic.Config{
+		QUICConfig: &quic.Config{
 			EnableDatagrams:   true,
 			InitialPacketSize: 1350,
 		},
-	)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to dial QUIC connection: %w", err)
+		DialAddr: func(ctx context.Context, _ string, tlsConf *tls.Config, quicConf *quic.Config) (*quic.Conn, error) {
+			return quic.DialAddr(ctx, proxyAddr.String(), tlsConf, quicConf)
+		},
 	}
-
-	tr := &http3.Transport{EnableDatagrams: true}
-	hconn := tr.NewClientConn(conn)
-
 	template := uritemplate.MustNew(fmt.Sprintf("https://proxy:%d/vpn", proxyAddr.Port()))
-	ipconn, rsp, err := connectip.Dial(ctx, hconn, template)
+	req, err := connectip.NewRequest(ctx, template)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create connect-ip request: %w", err)
+	}
+	ipconn, rsp, err := tr.Dial(req)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to dial connect-ip connection: %w", err)
 	}

--- a/integration/proxy/proxy.go
+++ b/integration/proxy/proxy.go
@@ -179,9 +179,9 @@ func run(bindTo netip.AddrPort, remoteAddr netip.Addr, route netip.Prefix, ipPro
 	p := connectip.Proxy{}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/vpn", func(w http.ResponseWriter, r *http.Request) {
-		req, err := connectip.ParseRequest(r, template)
+		req, err := connectip.ParseProxyRequest(r, template)
 		if err != nil {
-			if perr, ok := errors.AsType[*connectip.RequestParseError](err); ok {
+			if perr, ok := errors.AsType[*connectip.ProxyRequestParseError](err); ok {
 				w.WriteHeader(perr.HTTPStatus)
 				return
 			}

--- a/proxy.go
+++ b/proxy.go
@@ -11,10 +11,10 @@ var contextIDZero = quicvarint.Append([]byte{}, 0)
 
 type Proxy struct{}
 
-func (s *Proxy) Proxy(w http.ResponseWriter, _ *Request) (*Conn, error) {
+func (s *Proxy) Proxy(w http.ResponseWriter, _ *ProxyRequest) (*Conn, error) {
 	w.Header().Set(http3.CapsuleProtocolHeader, capsuleProtocolHeaderValue)
 	w.WriteHeader(http.StatusOK)
 
 	str := w.(http3.HTTPStreamer).HTTPStream()
-	return newProxiedConn(str), nil
+	return newProxiedConn(str, nil), nil
 }

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
 	"github.com/yosida95/uritemplate/v3"
 	"golang.org/x/net/ipv4"
@@ -27,11 +26,12 @@ func setupConns(t *testing.T) (client, server *Conn) {
 	require.NoError(t, err)
 	t.Cleanup(func() { conn.Close() })
 
-	template := uritemplate.MustNew(fmt.Sprintf("https://localhost:%d/connect-ip", conn.LocalAddr().(*net.UDPAddr).Port))
+	template := uritemplate.MustNew(fmt.Sprintf("https://%s/connect-ip", conn.LocalAddr()))
 	connChan := make(chan *Conn, 1)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/connect-ip", func(w http.ResponseWriter, r *http.Request) {
-		mreq, err := ParseRequest(r, template)
+		require.Equal(t, "Bearer token", r.Header.Get("Authorization"))
+		mreq, err := ParseProxyRequest(r, template)
 		require.NoError(t, err)
 
 		conn, err := p.Proxy(w, mreq)
@@ -47,24 +47,16 @@ func setupConns(t *testing.T) (client, server *Conn) {
 	go func() { s.Serve(conn) }()
 	t.Cleanup(func() { s.Close() })
 
-	udpConn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
-	require.NoError(t, err)
-	t.Cleanup(func() { udpConn.Close() })
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()
-	cconn, err := quic.Dial(
-		ctx,
-		udpConn,
-		conn.LocalAddr(),
-		&tls.Config{ServerName: "localhost", RootCAs: certPool, NextProtos: []string{http3.NextProtoH3}},
-		&quic.Config{EnableDatagrams: true},
-	)
+	req, err := NewRequest(ctx, template)
 	require.NoError(t, err)
-	tr := &http3.Transport{EnableDatagrams: true}
-	t.Cleanup(func() { tr.Close() })
-
-	client, rsp, err := Dial(ctx, tr.NewClientConn(cconn), template)
+	req.Header().Set("Authorization", "Bearer token")
+	client, rsp, err := (&Transport{
+		TLSClientConfig: &tls.Config{ServerName: "localhost", RootCAs: certPool, NextProtos: []string{http3.NextProtoH3}},
+	}).Dial(req)
 	require.NoError(t, err)
+	t.Cleanup(func() { client.Close() })
 	require.Equal(t, rsp.StatusCode, http.StatusOK)
 
 	select {

--- a/request.go
+++ b/request.go
@@ -1,6 +1,7 @@
 package connectip
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -24,77 +25,106 @@ func init() {
 	capsuleProtocolHeaderValue = v
 }
 
-// Request is the parsed CONNECT-IP request returned from ParseRequest.
-// It currently doesn't have any fields, since masque-go doesn't support IP flow forwarding.
-type Request struct{}
+// Request is a CONNECT-IP request created by NewRequest.
+// The zero value is not valid.
+type Request struct {
+	req *http.Request
+}
 
-// RequestParseError is returned from ParseRequest if parsing the CONNECT-UDP request fails.
+// NewRequest creates a CONNECT-IP request.
+func NewRequest(ctx context.Context, proxyTemplate *uritemplate.Template) (*Request, error) {
+	// connect-ip-go currently does not support IP flow forwarding,
+	// see https://github.com/quic-go/connect-ip-go/issues/31.
+	if len(proxyTemplate.Varnames()) > 0 {
+		return nil, errors.New("connect-ip: IP flow forwarding not supported")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodConnect, proxyTemplate.Raw(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("connect-ip: failed to create request: %w", err)
+	}
+	req.Proto = requestProtocol
+	req.Host = req.URL.Host
+	req.Header.Set(http3.CapsuleProtocolHeader, capsuleProtocolHeaderValue)
+	return &Request{req: req}, nil
+}
+
+// Header returns the HTTP header fields sent with the CONNECT-IP request.
+// Callers may add custom headers before dialing.
+func (r *Request) Header() http.Header { return r.req.Header }
+
+func (r *Request) httpRequest() *http.Request { return r.req }
+
+// ProxyRequest is the parsed CONNECT-IP request returned from ParseProxyRequest.
+// It currently doesn't have any fields, since connect-ip-go doesn't support IP flow forwarding.
+type ProxyRequest struct{}
+
+// ProxyRequestParseError is returned from ParseProxyRequest if parsing the CONNECT-IP request fails.
 // It is recommended that the request is rejected with the corresponding HTTP status code.
-type RequestParseError struct {
+type ProxyRequestParseError struct {
 	HTTPStatus int
 	Err        error
 }
 
-func (e *RequestParseError) Error() string { return e.Err.Error() }
-func (e *RequestParseError) Unwrap() error { return e.Err }
+func (e *ProxyRequestParseError) Error() string { return e.Err.Error() }
+func (e *ProxyRequestParseError) Unwrap() error { return e.Err }
 
-// ParseRequest parses a CONNECT-IP request.
+// ParseProxyRequest parses a CONNECT-IP request.
 // The template is the URI template that clients will use to configure this proxy.
-func ParseRequest(r *http.Request, template *uritemplate.Template) (*Request, error) {
+func ParseProxyRequest(r *http.Request, template *uritemplate.Template) (*ProxyRequest, error) {
 	if len(template.Varnames()) > 0 {
 		return nil, errors.New("connect-ip-go currently does not support IP flow forwarding")
 	}
 
 	u, err := url.Parse(template.Raw())
 	if err != nil {
-		return nil, &RequestParseError{
+		return nil, &ProxyRequestParseError{
 			HTTPStatus: http.StatusInternalServerError,
 			Err:        fmt.Errorf("failed to parse template: %w", err),
 		}
 	}
 	if r.Method != http.MethodConnect {
-		return nil, &RequestParseError{
+		return nil, &ProxyRequestParseError{
 			HTTPStatus: http.StatusMethodNotAllowed,
 			Err:        fmt.Errorf("expected CONNECT request, got %s", r.Method),
 		}
 	}
 	if r.Proto != requestProtocol {
-		return nil, &RequestParseError{
+		return nil, &ProxyRequestParseError{
 			HTTPStatus: http.StatusNotImplemented,
 			Err:        fmt.Errorf("unexpected protocol: %s", r.Proto),
 		}
 	}
 	if r.Host != u.Host {
-		return nil, &RequestParseError{
+		return nil, &ProxyRequestParseError{
 			HTTPStatus: http.StatusBadRequest,
 			Err:        fmt.Errorf("host in :authority (%s) does not match template host (%s)", r.Host, u.Host),
 		}
 	}
 	capsuleHeaderValues, ok := r.Header[http3.CapsuleProtocolHeader]
 	if !ok {
-		return nil, &RequestParseError{
+		return nil, &ProxyRequestParseError{
 			HTTPStatus: http.StatusBadRequest,
 			Err:        fmt.Errorf("missing Capsule-Protocol header"),
 		}
 	}
 	item, err := httpsfv.UnmarshalItem(capsuleHeaderValues)
 	if err != nil {
-		return nil, &RequestParseError{
+		return nil, &ProxyRequestParseError{
 			HTTPStatus: http.StatusBadRequest,
 			Err:        fmt.Errorf("invalid capsule header value: %s", capsuleHeaderValues),
 		}
 	}
 	if v, ok := item.Value.(bool); !ok {
-		return nil, &RequestParseError{
+		return nil, &ProxyRequestParseError{
 			HTTPStatus: http.StatusBadRequest,
 			Err:        fmt.Errorf("incorrect capsule header value type: %s", reflect.TypeOf(item.Value)),
 		}
 	} else if !v {
-		return nil, &RequestParseError{
+		return nil, &ProxyRequestParseError{
 			HTTPStatus: http.StatusBadRequest,
 			Err:        fmt.Errorf("incorrect capsule header value: %t", item.Value),
 		}
 	}
 
-	return &Request{}, nil
+	return &ProxyRequest{}, nil
 }

--- a/request_test.go
+++ b/request_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/dunglas/httpsfv"
+	"github.com/quic-go/quic-go/http3"
 	"github.com/stretchr/testify/require"
 	"github.com/yosida95/uritemplate/v3"
 )
@@ -18,19 +19,36 @@ func newRequest(target string) *http.Request {
 	return req
 }
 
-func TestConnectIPRequestParsing(t *testing.T) {
+func TestNewRequest(t *testing.T) {
+	template := uritemplate.MustNew("https://localhost:1234/masque/ip")
+	req, err := NewRequest(t.Context(), template)
+	require.NoError(t, err)
+	httpReq := req.httpRequest()
+	require.Equal(t, http.MethodConnect, httpReq.Method)
+	require.Equal(t, requestProtocol, httpReq.Proto)
+	require.Equal(t, "localhost:1234", httpReq.Host)
+	require.Equal(t, capsuleProtocolHeaderValue, req.Header().Get(http3.CapsuleProtocolHeader))
+
+	req.Header().Set("Authorization", "Bearer token")
+	require.Equal(t, "Bearer token", httpReq.Header.Get("Authorization"))
+
+	_, err = NewRequest(t.Context(), uritemplate.MustNew("https://localhost/{target}"))
+	require.ErrorContains(t, err, "IP flow forwarding not supported")
+}
+
+func TestProxyRequestParsing(t *testing.T) {
 	t.Run("valid request", func(t *testing.T) {
 		template := uritemplate.MustNew("https://localhost:1234/masque/ip")
 		req := newRequest("https://localhost:1234/masque/ip")
-		r, err := ParseRequest(req, template)
+		r, err := ParseProxyRequest(req, template)
 		require.NoError(t, err)
-		require.Equal(t, &Request{}, r)
+		require.Equal(t, &ProxyRequest{}, r)
 	})
 
 	t.Run("reject templates with variables", func(t *testing.T) {
 		template := uritemplate.MustNew("https://localhost:1234/masque/ip?t={target}&i={ipproto}")
 		req := newRequest("https://localhost:1234/masque/ip?t=foobar&i=42")
-		_, err := ParseRequest(req, template)
+		_, err := ParseProxyRequest(req, template)
 		require.EqualError(t, err, "connect-ip-go currently does not support IP flow forwarding")
 	})
 
@@ -39,48 +57,48 @@ func TestConnectIPRequestParsing(t *testing.T) {
 	t.Run("wrong protocol", func(t *testing.T) {
 		req := newRequest("https://localhost:1234/masque")
 		req.Proto = "not-connect-ip"
-		_, err := ParseRequest(req, template)
+		_, err := ParseProxyRequest(req, template)
 		require.EqualError(t, err, "unexpected protocol: not-connect-ip")
-		require.Equal(t, http.StatusNotImplemented, err.(*RequestParseError).HTTPStatus)
+		require.Equal(t, http.StatusNotImplemented, err.(*ProxyRequestParseError).HTTPStatus)
 	})
 
 	t.Run("wrong request method", func(t *testing.T) {
 		req := newRequest("https://localhost:1234/masque")
 		req.Method = http.MethodHead
-		_, err := ParseRequest(req, template)
+		_, err := ParseProxyRequest(req, template)
 		require.EqualError(t, err, "expected CONNECT request, got HEAD")
-		require.Equal(t, http.StatusMethodNotAllowed, err.(*RequestParseError).HTTPStatus)
+		require.Equal(t, http.StatusMethodNotAllowed, err.(*ProxyRequestParseError).HTTPStatus)
 	})
 
 	t.Run("wrong :authority", func(t *testing.T) {
 		req := newRequest("https://quic-go.net:1234/masque")
-		_, err := ParseRequest(req, template)
+		_, err := ParseProxyRequest(req, template)
 		require.EqualError(t, err, "host in :authority (quic-go.net:1234) does not match template host (localhost:1234)")
-		require.Equal(t, http.StatusBadRequest, err.(*RequestParseError).HTTPStatus)
+		require.Equal(t, http.StatusBadRequest, err.(*ProxyRequestParseError).HTTPStatus)
 	})
 
 	t.Run("missing Capsule-Protocol header", func(t *testing.T) {
 		req := newRequest("https://localhost:1234/masque")
 		req.Header.Del("Capsule-Protocol")
-		_, err := ParseRequest(req, template)
+		_, err := ParseProxyRequest(req, template)
 		require.EqualError(t, err, "missing Capsule-Protocol header")
-		require.Equal(t, http.StatusBadRequest, err.(*RequestParseError).HTTPStatus)
+		require.Equal(t, http.StatusBadRequest, err.(*ProxyRequestParseError).HTTPStatus)
 	})
 
 	t.Run("invalid Capsule-Protocol header", func(t *testing.T) {
 		req := newRequest("https://localhost:1234/masque")
 		req.Header.Set("Capsule-Protocol", "🤡")
-		_, err := ParseRequest(req, template)
+		_, err := ParseProxyRequest(req, template)
 		require.EqualError(t, err, "invalid capsule header value: [🤡]")
-		require.Equal(t, http.StatusBadRequest, err.(*RequestParseError).HTTPStatus)
+		require.Equal(t, http.StatusBadRequest, err.(*ProxyRequestParseError).HTTPStatus)
 	})
 
 	t.Run("invalid Capsule-Protocol header value type", func(t *testing.T) {
 		req := newRequest("https://localhost:1234/masque")
 		req.Header.Set("Capsule-Protocol", "1")
-		_, err := ParseRequest(req, template)
+		_, err := ParseProxyRequest(req, template)
 		require.EqualError(t, err, "incorrect capsule header value type: int64")
-		require.Equal(t, http.StatusBadRequest, err.(*RequestParseError).HTTPStatus)
+		require.Equal(t, http.StatusBadRequest, err.(*ProxyRequestParseError).HTTPStatus)
 	})
 
 	t.Run("invalid Capsule-Protocol header value", func(t *testing.T) {
@@ -88,8 +106,8 @@ func TestConnectIPRequestParsing(t *testing.T) {
 		v, err := httpsfv.Marshal(httpsfv.NewItem(false))
 		require.NoError(t, err)
 		req.Header.Set("Capsule-Protocol", v)
-		_, err = ParseRequest(req, template)
+		_, err = ParseProxyRequest(req, template)
 		require.EqualError(t, err, "incorrect capsule header value: false")
-		require.Equal(t, http.StatusBadRequest, err.(*RequestParseError).HTTPStatus)
+		require.Equal(t, http.StatusBadRequest, err.(*ProxyRequestParseError).HTTPStatus)
 	})
 }

--- a/transport.go
+++ b/transport.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 
 	"github.com/quic-go/quic-go"
@@ -52,7 +53,11 @@ func (t *Transport) Dial(req *Request) (*Conn, *http.Response, error) {
 	if dial == nil {
 		dial = quic.DialAddr
 	}
-	conn, err := dial(httpReq.Context(), httpReq.URL.Host, tlsConf, quicConf)
+	addr := httpReq.URL.Host
+	if httpReq.URL.Port() == "" {
+		addr = net.JoinHostPort(httpReq.URL.Hostname(), "443")
+	}
+	conn, err := dial(httpReq.Context(), addr, tlsConf, quicConf)
 	if err != nil {
 		return nil, nil, fmt.Errorf("connect-ip: dialing QUIC connection failed: %w", err)
 	}

--- a/transport.go
+++ b/transport.go
@@ -1,0 +1,82 @@
+package connectip
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
+)
+
+// defaultInitialPacketSize allows tunneling QUIC connections, which require an MTU of at least 1200 bytes.
+const defaultInitialPacketSize = 1350
+
+// A Transport establishes proxied connections to multiple proxy servers.
+type Transport struct {
+	// TLSClientConfig is the TLS client config used when dialing the QUIC connection to the proxy.
+	// It must set the "h3" ALPN.
+	TLSClientConfig *tls.Config
+
+	// QUICConfig is the QUIC config used when dialing the QUIC connection.
+	QUICConfig *quic.Config
+
+	// DialAddr dials the QUIC connection to the proxy.
+	// If unset, quic.DialAddr is used.
+	DialAddr func(ctx context.Context, addr string, tlsConf *tls.Config, quicConf *quic.Config) (*quic.Conn, error)
+}
+
+// Dial opens a QUIC connection to the proxy and then dials a proxied connection.
+// Closing the returned Conn also closes the QUIC connection to the proxy.
+// To establish multiple proxied connections over one proxy connection, use NewClientConn.
+func (t *Transport) Dial(req *Request) (*Conn, *http.Response, error) {
+	httpReq := req.httpRequest()
+	if httpReq.URL == nil || httpReq.URL.Host == "" {
+		return nil, nil, errors.New("connect-ip: request URL needs a host")
+	}
+
+	quicConf := t.QUICConfig
+	if quicConf == nil {
+		quicConf = &quic.Config{EnableDatagrams: true, InitialPacketSize: defaultInitialPacketSize}
+	}
+	if !quicConf.EnableDatagrams {
+		return nil, nil, errors.New("connect-ip: QUICConfig needs to enable datagrams")
+	}
+	tlsConf := t.TLSClientConfig
+	if tlsConf == nil {
+		tlsConf = &tls.Config{NextProtos: []string{http3.NextProtoH3}}
+	}
+	dial := t.DialAddr
+	if dial == nil {
+		dial = quic.DialAddr
+	}
+	conn, err := dial(httpReq.Context(), httpReq.URL.Host, tlsConf, quicConf)
+	if err != nil {
+		return nil, nil, fmt.Errorf("connect-ip: dialing QUIC connection failed: %w", err)
+	}
+	c, err := t.NewClientConn(conn)
+	if err != nil {
+		conn.CloseWithError(0, "")
+		return nil, nil, err
+	}
+	pconn, rsp, err := c.dial(req, func() error { return conn.CloseWithError(0, "") })
+	if err != nil {
+		conn.CloseWithError(0, "")
+		return nil, rsp, err
+	}
+	return pconn, rsp, nil
+}
+
+// NewClientConn creates a client connection for an already established QUIC connection.
+// It returns an error if the QUIC connection didn't negotiate datagram support.
+// The caller owns the QUIC connection and closes it when done.
+func (t *Transport) NewClientConn(conn *quic.Conn) (*ClientConn, error) {
+	datagrams := conn.ConnectionState().SupportsDatagrams
+	if !datagrams.Local || !datagrams.Remote {
+		return nil, errors.New("connect-ip: QUIC connection needs datagram support")
+	}
+	tr := &http3.Transport{EnableDatagrams: true}
+	return &ClientConn{clientConn: tr.NewClientConn(conn)}, nil
+}

--- a/transport_test.go
+++ b/transport_test.go
@@ -1,0 +1,43 @@
+package connectip
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
+	"github.com/stretchr/testify/require"
+	"github.com/yosida95/uritemplate/v3"
+)
+
+func TestTransportRequiresDatagrams(t *testing.T) {
+	req, err := NewRequest(t.Context(), uritemplate.MustNew("https://localhost/connect-ip"))
+	require.NoError(t, err)
+	_, _, err = (&Transport{QUICConfig: &quic.Config{}}).Dial(req)
+	require.ErrorContains(t, err, "QUICConfig needs to enable datagrams")
+}
+
+func TestNewClientConnRequiresDatagrams(t *testing.T) {
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	require.NoError(t, err)
+	ln, err := quic.Listen(conn, tlsConf, nil)
+	require.NoError(t, err)
+	defer ln.Close()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	cconn, err := quic.DialAddr(
+		ctx,
+		conn.LocalAddr().String(),
+		&tls.Config{ServerName: "localhost", RootCAs: certPool, NextProtos: []string{http3.NextProtoH3}},
+		&quic.Config{EnableDatagrams: true},
+	)
+	require.NoError(t, err)
+	defer cconn.CloseWithError(0, "")
+
+	_, err = new(Transport).NewClientConn(cconn)
+	require.ErrorContains(t, err, "QUIC connection needs datagram support")
+}

--- a/transport_test.go
+++ b/transport_test.go
@@ -3,6 +3,7 @@ package connectip
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"net"
 	"testing"
 	"time"
@@ -18,6 +19,20 @@ func TestTransportRequiresDatagrams(t *testing.T) {
 	require.NoError(t, err)
 	_, _, err = (&Transport{QUICConfig: &quic.Config{}}).Dial(req)
 	require.ErrorContains(t, err, "QUICConfig needs to enable datagrams")
+}
+
+func TestTransportAddsDefaultPort(t *testing.T) {
+	req, err := NewRequest(t.Context(), uritemplate.MustNew("https://proxy.example/connect-ip"))
+	require.NoError(t, err)
+	var addr string
+	_, _, err = (&Transport{
+		DialAddr: func(_ context.Context, got string, _ *tls.Config, _ *quic.Config) (*quic.Conn, error) {
+			addr = got
+			return nil, errors.New("stop before dialing")
+		},
+	}).Dial(req)
+	require.Error(t, err)
+	require.Equal(t, "proxy.example:443", addr)
 }
 
 func TestNewClientConnRequiresDatagrams(t *testing.T) {


### PR DESCRIPTION
This is intentionally very close to what we implemented for masque-go: https://github.com/quic-go/masque-go/pull/126.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Transport` and `ClientConn` abstractions for CONNECT-IP proxy dialing
> - Introduces `connectip.Transport` ([transport.go](https://github.com/quic-go/connect-ip-go/pull/75/files#diff-5982a4ca350449c8a5deba675bc4bc4bb0f1823c45e6c7ba0076cc6b159fef8f)) for one-shot dialing that establishes a QUIC connection and CONNECT-IP tunnel, managing TLS/QUIC config defaults and closing the QUIC connection when the `Conn` closes
> - Introduces `connectip.ClientConn` ([client.go](https://github.com/quic-go/connect-ip-go/pull/75/files#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cf)) to reuse a single proxy HTTP/3 connection for multiple proxied tunnels via `ClientConn.Dial`
> - Adds `connectip.Request` and `NewRequest` ([request.go](https://github.com/quic-go/connect-ip-go/pull/75/files#diff-3c2feffcf57ffb6c596dc5608186c518252092b7017be5189d3dc12aa3c45cec)) to construct and validate CONNECT-IP requests with correct headers; renames proxy-side types to `ProxyRequest`, `ProxyRequestParseError`, and `ParseProxyRequest`
> - Removes the package-level `connectip.Dial` function; callers now use `Transport.Dial` or `Transport.NewClientConn` plus `ClientConn.Dial`
> - `newProxiedConn` and `Conn.Close` now accept and invoke an optional `closeConn` callback to close upstream resources
> - Behavioral Change: `Transport.NewClientConn` rejects QUIC connections that did not negotiate datagram support; `Transport.Dial` enforces datagrams in `QUICConfig` and defaults the port to 443 when absent; `Proxy.Proxy` now takes `*ProxyRequest` instead of `*Request`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d534a9e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added a transport-based client API for establishing proxied QUIC connections.
- Added request construction for CONNECT-IP requests, including headers and protocol details.
- Added support for reusing existing HTTP/3 client connections.
- Added validation for request hosts and required QUIC datagram support.

## Improvements
- Connections now clean up owned resources automatically when closed.
- Proxy request parsing and error reporting are clearer and more distinct between client and server flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->