### PR TITLE
replace capsule coalescing with a bounded queue

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -51,6 +51,10 @@ var (
 // On IPv6, the minimum MTU of a link is 1280 bytes.
 const minMTU = 1280
 
+// Capsules normally don't remain queued: they are written to the CONNECT stream
+// immediately. The queue only grows if the peer falls behind processing the stream.
+const maxQueuedCapsules = 128
+
 // Conn is a connection that proxies IP packets over HTTP/3.
 type Conn struct {
 	str         http3Stream
@@ -106,8 +110,7 @@ func newProxiedConn(str http3Stream, closeConn func() error) *Conn {
 }
 
 // AdvertiseRoute schedules an advertisement of the available routes to the peer.
-// It returns once the advertisement has been queued. A later call can replace a
-// queued advertisement that has not yet been written.
+// It returns once the advertisement has been queued.
 func (c *Conn) AdvertiseRoute(routes []IPRoute) error {
 	for _, route := range routes {
 		if route.StartIP.Compare(route.EndIP) == 1 {
@@ -116,20 +119,26 @@ func (c *Conn) AdvertiseRoute(routes []IPRoute) error {
 	}
 
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	if c.closeErr != nil {
-		return c.closeErr
+		err := c.closeErr
+		c.mu.Unlock()
+		return err
 	}
 	routes = slices.Clone(routes)
-	c.localRoutes = routes
-	c.queueCapsule(&routeAdvertisementCapsule{IPAddressRanges: routes})
+	err := c.queueCapsule(&routeAdvertisementCapsule{IPAddressRanges: routes})
+	if err == nil {
+		c.localRoutes = routes
+	}
+	c.mu.Unlock()
+	if err != nil {
+		_ = c.Close()
+		return err
+	}
 	return nil
 }
 
 // AssignAddresses schedules an assignment of address prefixes to the peer.
-// It returns once the assignment has been queued. A later call can replace a
-// queued assignment that has not yet been written.
+// It returns once the assignment has been queued.
 func (c *Conn) AssignAddresses(prefixes []netip.Prefix) error {
 	capsule := &addressAssignCapsule{AssignedAddresses: make([]AssignedAddress, 0, len(prefixes))}
 	for _, p := range prefixes {
@@ -137,42 +146,36 @@ func (c *Conn) AssignAddresses(prefixes []netip.Prefix) error {
 	}
 
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	if c.closeErr != nil {
-		return c.closeErr
+		err := c.closeErr
+		c.mu.Unlock()
+		return err
 	}
-	c.peerAddresses = slices.Clone(prefixes)
-	c.queueCapsule(capsule)
+	err := c.queueCapsule(capsule)
+	if err == nil {
+		c.peerAddresses = slices.Clone(prefixes)
+	}
+	c.mu.Unlock()
+	if err != nil {
+		_ = c.Close()
+		return err
+	}
 	return nil
 }
 
-func (c *Conn) queueCapsule(capsule appendable) {
-	// Replace the latest capsule of the same type.
-	// This bounds the memory commitment from queued capsules,
-	// as it limits the size of the queue to the number of capsule types.
-	for i, queued := range c.queuedCapsules {
-		switch queued.(type) {
-		case *addressAssignCapsule:
-			if _, ok := capsule.(*addressAssignCapsule); !ok {
-				continue
-			}
-		case *routeAdvertisementCapsule:
-			if _, ok := capsule.(*routeAdvertisementCapsule); !ok {
-				continue
-			}
-		default:
-			continue
-		}
-		c.queuedCapsules = slices.Delete(c.queuedCapsules, i, i+1)
-		break
+func (c *Conn) queueCapsule(capsule appendable) error {
+	if len(c.queuedCapsules) >= maxQueuedCapsules {
+		return errors.New("connect-ip: capsule queue full")
 	}
+	// Consecutive capsules of the same type could be coalesced here, but that
+	// micro-optimization is not worth the added complexity without evidence.
 	c.queuedCapsules = append(c.queuedCapsules, capsule)
 
 	select {
 	case c.writeNotify <- struct{}{}:
 	default:
 	}
+	return nil
 }
 
 // LocalPrefixes returns the prefixes that the peer currently assigned.
@@ -276,6 +279,7 @@ func (c *Conn) writeToStream() error {
 					break
 				}
 				capsule := c.queuedCapsules[0]
+				c.queuedCapsules[0] = nil
 				c.queuedCapsules = c.queuedCapsules[1:]
 				c.mu.Unlock()
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -12,7 +12,6 @@ import (
 	"golang.org/x/net/ipv6"
 
 	"github.com/quic-go/quic-go"
-	"github.com/quic-go/quic-go/http3"
 	"github.com/quic-go/quic-go/quicvarint"
 
 	"github.com/stretchr/testify/require"
@@ -67,7 +66,7 @@ func (m *mockStream) ReceiveDatagram(ctx context.Context) ([]byte, error) {
 	return nil, ctx.Err()
 }
 
-func TestCapsuleWritesAreCoalesced(t *testing.T) {
+func TestCapsuleQueueLimit(t *testing.T) {
 	writes := make(chan []byte)
 	writeStarted := make(chan struct{})
 	conn := newProxiedConn(&mockStream{
@@ -76,8 +75,6 @@ func TestCapsuleWritesAreCoalesced(t *testing.T) {
 	}, nil)
 	t.Cleanup(func() { conn.Close() })
 
-	// Block the first write. While it is blocked, the remaining calls stay queued,
-	// and the newer capsule of each type replaces the older one.
 	require.NoError(t, conn.AssignAddresses(nil))
 	select {
 	case <-writeStarted:
@@ -85,37 +82,14 @@ func TestCapsuleWritesAreCoalesced(t *testing.T) {
 		t.Fatal("capsule write did not start")
 	}
 
-	oldPrefix := netip.MustParsePrefix("192.0.2.1/32")
-	wantPrefix := netip.MustParsePrefix("2001:db8::/64")
-	oldIP := netip.MustParseAddr("192.0.2.1")
-	wantIP := netip.MustParseAddr("2001:db8::1")
-	oldRoute := IPRoute{StartIP: oldIP, EndIP: oldIP}
-	wantRoute := IPRoute{StartIP: wantIP, EndIP: wantIP}
-	require.NoError(t, conn.AssignAddresses([]netip.Prefix{oldPrefix}))
-	require.NoError(t, conn.AdvertiseRoute([]IPRoute{oldRoute}))
-	require.NoError(t, conn.AssignAddresses([]netip.Prefix{wantPrefix}))
-	require.NoError(t, conn.AdvertiseRoute([]IPRoute{wantRoute}))
-
-	var assignedAddresses []AssignedAddress
-	var advertisedRoutes []IPRoute
-	for range 3 {
-		typ, r, err := http3.NewCapsuleParser(bytes.NewReader(<-writes)).Next()
-		require.NoError(t, err)
-		switch typ {
-		case capsuleTypeAddressAssign:
-			capsule, err := parseAddressAssignCapsule(r)
-			require.NoError(t, err)
-			assignedAddresses = append(assignedAddresses, capsule.AssignedAddresses...)
-		case capsuleTypeRouteAdvertisement:
-			capsule, err := parseRouteAdvertisementCapsule(r)
-			require.NoError(t, err)
-			advertisedRoutes = append(advertisedRoutes, capsule.IPAddressRanges...)
-		default:
-			t.Fatalf("unexpected capsule type: %d", typ)
-		}
+	for range maxQueuedCapsules {
+		require.NoError(t, conn.AssignAddresses(nil))
 	}
-	require.Equal(t, []AssignedAddress{{IPPrefix: wantPrefix}}, assignedAddresses)
-	require.Equal(t, []IPRoute{wantRoute}, advertisedRoutes)
+	require.ErrorContains(t, conn.AssignAddresses(nil), "capsule queue full")
+	require.ErrorIs(t, conn.AssignAddresses(nil), net.ErrClosed)
+
+	// Let the writer finish the in-progress write and observe the closed connection.
+	<-writes
 }
 
 func TestIncomingDatagrams(t *testing.T) {


### PR DESCRIPTION
The replacement logic introduced in #74 was too clever. With the DNS extension (#62), the order in which capsules are sent and received matters, and there's no good way to preserve that if we are replacing existing capsules.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace capsule coalescing with a bounded queue capped at `128` in `Conn`
> - Introduces `maxQueuedCapsules` (`128`) and makes `Conn.queueCapsule` return an error when the queue is full instead of overwriting a previously queued capsule of the same type
> - `Conn.AdvertiseRoute` and `Conn.AssignAddresses` now close the connection and return the error when `queueCapsule` fails
> - `Conn.writeToStream` nils out popped queue entries to avoid retaining references
> - Risk: `Conn.AdvertiseRoute` and `Conn.AssignAddresses` no longer coalesce duplicate queued capsules, so repeated calls now grow the queue until it hits `maxQueuedCapsules`; exceeding the cap closes the `Conn`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c4e5fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Operations on closed connections now return clear errors.
  * Capsule queue overflow is reported instead of silently replacing previously queued items.
  * Connections close when the capsule queue reaches its limit, preventing uncontrolled queuing.
  * Improved resource cleanup for queued connection data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->