### PR TITLE
parse and validate the Service Parameters in the DNS_ASSIGN capsule

### DIFF
--- a/capsule.go
+++ b/capsule.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/netip"
 
+	"golang.org/x/net/dns/dnsmessage"
+
 	"github.com/quic-go/quic-go/http3"
 	"github.com/quic-go/quic-go/quicvarint"
 )
@@ -373,11 +375,28 @@ func parseDNSNameserver(r http3.CapsuleReader) (DNSNameserver, error) {
 	if paramsLen > uint64(r.Remaining()) {
 		return DNSNameserver{}, io.ErrUnexpectedEOF
 	}
-	var serviceParameters []byte
+	var serviceParameters []dnsmessage.SVCParam
 	if paramsLen > 0 {
-		serviceParameters = make([]byte, int(paramsLen))
-		if _, err := io.ReadFull(r, serviceParameters); err != nil {
+		b := make([]byte, int(paramsLen))
+		if _, err := io.ReadFull(r, b); err != nil {
 			return DNSNameserver{}, err
+		}
+		for len(b) > 0 {
+			if len(b) < 4 {
+				return DNSNameserver{}, fmt.Errorf("invalid service parameter header: %w", io.ErrUnexpectedEOF)
+			}
+			key := binary.BigEndian.Uint16(b)
+			valueLen := int(binary.BigEndian.Uint16(b[2:]))
+			b = b[4:]
+			if valueLen > len(b) {
+				return DNSNameserver{}, fmt.Errorf("invalid service parameter value: %w", io.ErrUnexpectedEOF)
+			}
+			serviceParameters = append(serviceParameters, dnsmessage.SVCParam{
+				Key: dnsmessage.SVCParamKey(key),
+				// the second index sets capacity so append on Value can't overwrite later parameters
+				Value: b[:valueLen:valueLen],
+			})
+			b = b[valueLen:]
 		}
 	}
 	return DNSNameserver{
@@ -411,19 +430,27 @@ func (c *dnsAssignCapsule) append(b []byte) []byte {
 	payload := make([]byte, 0, 256)
 	for _, cfg := range c.DNSConfigurations {
 		payload = quicvarint.Append(payload, uint64(len(cfg.Nameservers)))
-		for _, nameserver := range cfg.Nameservers {
-			payload = binary.BigEndian.AppendUint16(payload, nameserver.ServicePriority)
-			payload = quicvarint.Append(payload, uint64(len(nameserver.IPv4Addresses)))
-			for _, addr := range nameserver.IPv4Addresses {
+		for _, ns := range cfg.Nameservers {
+			payload = binary.BigEndian.AppendUint16(payload, ns.ServicePriority)
+			payload = quicvarint.Append(payload, uint64(len(ns.IPv4Addresses)))
+			for _, addr := range ns.IPv4Addresses {
 				payload = append(payload, addr.AsSlice()...)
 			}
-			payload = quicvarint.Append(payload, uint64(len(nameserver.IPv6Addresses)))
-			for _, addr := range nameserver.IPv6Addresses {
+			payload = quicvarint.Append(payload, uint64(len(ns.IPv6Addresses)))
+			for _, addr := range ns.IPv6Addresses {
 				payload = append(payload, addr.AsSlice()...)
 			}
-			payload = appendDomain(payload, nameserver.AuthenticationDomainName)
-			payload = quicvarint.Append(payload, uint64(len(nameserver.ServiceParameters)))
-			payload = append(payload, nameserver.ServiceParameters...)
+			payload = appendDomain(payload, ns.AuthenticationDomainName)
+			var l int
+			for _, p := range ns.ServiceParameters {
+				l += 4 + len(p.Value)
+			}
+			payload = quicvarint.Append(payload, uint64(l))
+			for _, p := range ns.ServiceParameters {
+				payload = binary.BigEndian.AppendUint16(payload, uint16(p.Key))
+				payload = binary.BigEndian.AppendUint16(payload, uint16(len(p.Value)))
+				payload = append(payload, p.Value...)
+			}
 		}
 		payload = quicvarint.Append(payload, uint64(len(cfg.InternalDomains)))
 		for _, domain := range cfg.InternalDomains {

--- a/capsule.go
+++ b/capsule.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/netip"
+	"slices"
 
 	"golang.org/x/net/dns/dnsmessage"
 
@@ -375,27 +377,30 @@ func parseDNSNameserver(r http3.CapsuleReader) (DNSNameserver, error) {
 	if paramsLen > uint64(r.Remaining()) {
 		return DNSNameserver{}, io.ErrUnexpectedEOF
 	}
-	var serviceParameters []dnsmessage.SVCParam
+	var serviceParameters map[dnsmessage.SVCParamKey][]byte
 	if paramsLen > 0 {
 		b := make([]byte, int(paramsLen))
 		if _, err := io.ReadFull(r, b); err != nil {
 			return DNSNameserver{}, err
 		}
+		serviceParameters = make(map[dnsmessage.SVCParamKey][]byte)
+		var previousKey dnsmessage.SVCParamKey
 		for len(b) > 0 {
 			if len(b) < 4 {
 				return DNSNameserver{}, fmt.Errorf("invalid service parameter header: %w", io.ErrUnexpectedEOF)
 			}
-			key := binary.BigEndian.Uint16(b)
+			key := dnsmessage.SVCParamKey(binary.BigEndian.Uint16(b))
 			valueLen := int(binary.BigEndian.Uint16(b[2:]))
 			b = b[4:]
 			if valueLen > len(b) {
 				return DNSNameserver{}, fmt.Errorf("invalid service parameter value: %w", io.ErrUnexpectedEOF)
 			}
-			serviceParameters = append(serviceParameters, dnsmessage.SVCParam{
-				Key: dnsmessage.SVCParamKey(key),
-				// the second index sets capacity so append on Value can't overwrite later parameters
-				Value: b[:valueLen:valueLen],
-			})
+			if len(serviceParameters) > 0 && key <= previousKey {
+				return DNSNameserver{}, errors.New("service parameter keys must be in strictly increasing order")
+			}
+			// The second index sets capacity so append on the value can't overwrite later parameters.
+			serviceParameters[key] = b[:valueLen:valueLen]
+			previousKey = key
 			b = b[valueLen:]
 		}
 	}
@@ -441,15 +446,17 @@ func (c *dnsAssignCapsule) append(b []byte) []byte {
 				payload = append(payload, addr.AsSlice()...)
 			}
 			payload = appendDomain(payload, ns.AuthenticationDomainName)
+			keys := slices.Sorted(maps.Keys(ns.ServiceParameters))
 			var l int
-			for _, p := range ns.ServiceParameters {
-				l += 4 + len(p.Value)
+			for _, key := range keys {
+				l += 4 + len(ns.ServiceParameters[key])
 			}
 			payload = quicvarint.Append(payload, uint64(l))
-			for _, p := range ns.ServiceParameters {
-				payload = binary.BigEndian.AppendUint16(payload, uint16(p.Key))
-				payload = binary.BigEndian.AppendUint16(payload, uint16(len(p.Value)))
-				payload = append(payload, p.Value...)
+			for _, key := range keys {
+				value := ns.ServiceParameters[key]
+				payload = binary.BigEndian.AppendUint16(payload, uint16(key))
+				payload = binary.BigEndian.AppendUint16(payload, uint16(len(value)))
+				payload = append(payload, value...)
 			}
 		}
 		payload = quicvarint.Append(payload, uint64(len(cfg.InternalDomains)))

--- a/capsule_test.go
+++ b/capsule_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/quic-go/quic-go/http3"
 	"github.com/quic-go/quic-go/quicvarint"
+	"golang.org/x/net/dns/dnsmessage"
 
 	"github.com/stretchr/testify/require"
 )
@@ -308,9 +309,9 @@ func TestParseDNSAssignCapsule(t *testing.T) {
 	payload = quicvarint.Append(payload, 1) // IPv6 Address Count
 	payload = append(payload, netip.MustParseAddr("2001:db8::1").AsSlice()...)
 	payload = appendDomain(payload, "resolver.example")
-	serviceParameters := []byte{0, 3, 0, 2, 0x21, 0x35} // port=853
-	payload = quicvarint.Append(payload, uint64(len(serviceParameters)))
-	payload = append(payload, serviceParameters...)
+	serviceParametersBytes := []byte{0, 3, 0, 2, 0x21, 0x35} // port=853
+	payload = quicvarint.Append(payload, uint64(len(serviceParametersBytes)))
+	payload = append(payload, serviceParametersBytes...)
 	payload = quicvarint.Append(payload, 1) // Internal Domain Count
 	payload = appendDomain(payload, "internal.example")
 	payload = quicvarint.Append(payload, 2) // Search Domain Count
@@ -340,7 +341,10 @@ func TestParseDNSAssignCapsule(t *testing.T) {
 					IPv4Addresses:            []netip.Addr{netip.MustParseAddr("192.0.2.33")},
 					IPv6Addresses:            []netip.Addr{netip.MustParseAddr("2001:db8::1")},
 					AuthenticationDomainName: "resolver.example",
-					ServiceParameters:        serviceParameters,
+					ServiceParameters: []dnsmessage.SVCParam{{
+						Key:   dnsmessage.SVCParamPort,
+						Value: []byte{0x21, 0x35},
+					}},
 				}},
 				InternalDomains: []string{"internal.example"},
 				SearchDomains:   []string{"internal.example", "example"},
@@ -363,7 +367,10 @@ func TestWriteDNSAssignCapsule(t *testing.T) {
 			Nameservers: []DNSNameserver{{
 				ServicePriority:          1,
 				AuthenticationDomainName: "masque.example.org",
-				ServiceParameters:        []byte{0, 1, 0, 3, 2, 'h', '3'},
+				ServiceParameters: []dnsmessage.SVCParam{
+					{Key: dnsmessage.SVCParamALPN, Value: []byte{2, 'h', '3'}},
+					{Key: dnsmessage.SVCParamNoDefaultALPN, Value: []byte{}},
+				},
 			}},
 			InternalDomains: []string{""},
 		},
@@ -465,6 +472,36 @@ func TestParseDNSAssignCapsuleInvalid(t *testing.T) {
 		require.Equal(t, int64(len("short")), r.Remaining())
 	})
 
+	t.Run("truncated service parameter value", func(t *testing.T) {
+		payload := quicvarint.Append(nil, 1) // Nameserver Count
+		payload = binary.BigEndian.AppendUint16(payload, 1)
+		payload = quicvarint.Append(payload, 0) // IPv4 Address Count
+		payload = quicvarint.Append(payload, 0) // IPv6 Address Count
+		payload = appendDomain(payload, "resolver.example")
+		payload = quicvarint.Append(payload, 5)
+		payload = append(payload, 0, 3, 0, 2, 0x21)
+		payload = quicvarint.Append(payload, 0)
+		payload = quicvarint.Append(payload, 0)
+
+		_, err := parseDNSAssignCapsule(newCapsuleReader(t, capsuleTypeDNSAssign, payload))
+		require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	})
+
+	t.Run("unordered service parameters", func(t *testing.T) {
+		payload := quicvarint.Append(nil, 1) // Nameserver Count
+		payload = binary.BigEndian.AppendUint16(payload, 1)
+		payload = quicvarint.Append(payload, 0) // IPv4 Address Count
+		payload = quicvarint.Append(payload, 0) // IPv6 Address Count
+		payload = appendDomain(payload, "resolver.example")
+		payload = quicvarint.Append(payload, 8)
+		payload = append(payload, 0, 3, 0, 0, 0, 1, 0, 0)
+		payload = quicvarint.Append(payload, 0)
+		payload = quicvarint.Append(payload, 0)
+
+		_, err := parseDNSAssignCapsule(newCapsuleReader(t, capsuleTypeDNSAssign, payload))
+		require.ErrorContains(t, err, "strictly increasing order")
+	})
+
 	t.Run("incomplete capsule", func(t *testing.T) {
 		data := (&dnsAssignCapsule{DNSConfigurations: []DNSConfiguration{
 			{
@@ -473,7 +510,10 @@ func TestParseDNSAssignCapsuleInvalid(t *testing.T) {
 					IPv4Addresses:            []netip.Addr{netip.MustParseAddr("192.0.2.53")},
 					IPv6Addresses:            []netip.Addr{netip.MustParseAddr("2001:db8::53")},
 					AuthenticationDomainName: "resolver.example",
-					ServiceParameters:        []byte{0, 3, 0, 2, 0x21, 0x35},
+					ServiceParameters: []dnsmessage.SVCParam{{
+						Key:   dnsmessage.SVCParamPort,
+						Value: []byte{0x21, 0x35},
+					}},
 				}},
 				InternalDomains: []string{"internal.example"},
 				SearchDomains:   []string{"internal.example", "example"},

--- a/capsule_test.go
+++ b/capsule_test.go
@@ -341,10 +341,9 @@ func TestParseDNSAssignCapsule(t *testing.T) {
 					IPv4Addresses:            []netip.Addr{netip.MustParseAddr("192.0.2.33")},
 					IPv6Addresses:            []netip.Addr{netip.MustParseAddr("2001:db8::1")},
 					AuthenticationDomainName: "resolver.example",
-					ServiceParameters: []dnsmessage.SVCParam{{
-						Key:   dnsmessage.SVCParamPort,
-						Value: []byte{0x21, 0x35},
-					}},
+					ServiceParameters: map[dnsmessage.SVCParamKey][]byte{
+						dnsmessage.SVCParamPort: {0x21, 0x35},
+					},
 				}},
 				InternalDomains: []string{"internal.example"},
 				SearchDomains:   []string{"internal.example", "example"},
@@ -367,9 +366,9 @@ func TestWriteDNSAssignCapsule(t *testing.T) {
 			Nameservers: []DNSNameserver{{
 				ServicePriority:          1,
 				AuthenticationDomainName: "masque.example.org",
-				ServiceParameters: []dnsmessage.SVCParam{
-					{Key: dnsmessage.SVCParamALPN, Value: []byte{2, 'h', '3'}},
-					{Key: dnsmessage.SVCParamNoDefaultALPN, Value: []byte{}},
+				ServiceParameters: map[dnsmessage.SVCParamKey][]byte{
+					dnsmessage.SVCParamNoDefaultALPN: {},
+					dnsmessage.SVCParamALPN:          {2, 'h', '3'},
 				},
 			}},
 			InternalDomains: []string{""},
@@ -392,6 +391,37 @@ func TestWriteDNSAssignCapsule(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, capsule, parsed)
 	require.Zero(t, r.Len())
+}
+
+func TestWriteDNSAssignCapsuleSortsServiceParameters(t *testing.T) {
+	capsule := &dnsAssignCapsule{DNSConfigurations: []DNSConfiguration{{
+		Nameservers: []DNSNameserver{{
+			ServicePriority:          1,
+			AuthenticationDomainName: "resolver.example",
+			ServiceParameters: map[dnsmessage.SVCParamKey][]byte{
+				dnsmessage.SVCParamPort:          {0, 53},
+				dnsmessage.SVCParamNoDefaultALPN: {},
+				dnsmessage.SVCParamALPN:          {2, 'h', '3'},
+			},
+		}},
+	}}}
+
+	payload := quicvarint.Append(nil, 1) // Nameserver Count
+	payload = binary.BigEndian.AppendUint16(payload, 1)
+	payload = quicvarint.Append(payload, 0) // IPv4 Address Count
+	payload = quicvarint.Append(payload, 0) // IPv6 Address Count
+	payload = appendDomain(payload, "resolver.example")
+	payload = quicvarint.Append(payload, 17) // Service Parameters Length
+	payload = append(payload, 0, 1, 0, 3, 2, 'h', '3')
+	payload = append(payload, 0, 2, 0, 0)
+	payload = append(payload, 0, 3, 0, 2, 0, 53)
+	payload = quicvarint.Append(payload, 0) // Internal Domain Count
+	payload = quicvarint.Append(payload, 0) // Search Domain Count
+	expected := quicvarint.Append(nil, uint64(capsuleTypeDNSAssign))
+	expected = quicvarint.Append(expected, uint64(len(payload)))
+	expected = append(expected, payload...)
+
+	require.Equal(t, expected, capsule.append(nil))
 }
 
 func TestParseDNSAssignCapsuleInvalid(t *testing.T) {
@@ -502,6 +532,21 @@ func TestParseDNSAssignCapsuleInvalid(t *testing.T) {
 		require.ErrorContains(t, err, "strictly increasing order")
 	})
 
+	t.Run("duplicate service parameters", func(t *testing.T) {
+		payload := quicvarint.Append(nil, 1) // Nameserver Count
+		payload = binary.BigEndian.AppendUint16(payload, 1)
+		payload = quicvarint.Append(payload, 0) // IPv4 Address Count
+		payload = quicvarint.Append(payload, 0) // IPv6 Address Count
+		payload = appendDomain(payload, "resolver.example")
+		payload = quicvarint.Append(payload, 8)
+		payload = append(payload, 0, 3, 0, 0, 0, 3, 0, 0)
+		payload = quicvarint.Append(payload, 0)
+		payload = quicvarint.Append(payload, 0)
+
+		_, err := parseDNSAssignCapsule(newCapsuleReader(t, capsuleTypeDNSAssign, payload))
+		require.ErrorContains(t, err, "strictly increasing order")
+	})
+
 	t.Run("incomplete capsule", func(t *testing.T) {
 		data := (&dnsAssignCapsule{DNSConfigurations: []DNSConfiguration{
 			{
@@ -510,10 +555,9 @@ func TestParseDNSAssignCapsuleInvalid(t *testing.T) {
 					IPv4Addresses:            []netip.Addr{netip.MustParseAddr("192.0.2.53")},
 					IPv6Addresses:            []netip.Addr{netip.MustParseAddr("2001:db8::53")},
 					AuthenticationDomainName: "resolver.example",
-					ServiceParameters: []dnsmessage.SVCParam{{
-						Key:   dnsmessage.SVCParamPort,
-						Value: []byte{0x21, 0x35},
-					}},
+					ServiceParameters: map[dnsmessage.SVCParamKey][]byte{
+						dnsmessage.SVCParamPort: {0x21, 0x35},
+					},
 				}},
 				InternalDomains: []string{"internal.example"},
 				SearchDomains:   []string{"internal.example", "example"},

--- a/conn_test.go
+++ b/conn_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
 	"github.com/quic-go/quic-go/quicvarint"
+	"golang.org/x/net/dns/dnsmessage"
 
 	"github.com/stretchr/testify/require"
 )
@@ -101,7 +102,10 @@ func TestDNSConfiguration(t *testing.T) {
 				IPv4Addresses:            []netip.Addr{netip.MustParseAddr("192.0.2.53")},
 				IPv6Addresses:            []netip.Addr{netip.MustParseAddr("2001:db8::53")},
 				AuthenticationDomainName: "resolver.example",
-				ServiceParameters:        []byte{0, 3, 0, 2, 0x21, 0x35},
+				ServiceParameters: []dnsmessage.SVCParam{{
+					Key:   dnsmessage.SVCParamPort,
+					Value: []byte{0x21, 0x35},
+				}},
 			}},
 			InternalDomains: []string{"internal.example"},
 			SearchDomains:   []string{"internal.example", "example"},

--- a/conn_test.go
+++ b/conn_test.go
@@ -102,10 +102,9 @@ func TestDNSConfiguration(t *testing.T) {
 				IPv4Addresses:            []netip.Addr{netip.MustParseAddr("192.0.2.53")},
 				IPv6Addresses:            []netip.Addr{netip.MustParseAddr("2001:db8::53")},
 				AuthenticationDomainName: "resolver.example",
-				ServiceParameters: []dnsmessage.SVCParam{{
-					Key:   dnsmessage.SVCParamPort,
-					Value: []byte{0x21, 0x35},
-				}},
+				ServiceParameters: map[dnsmessage.SVCParamKey][]byte{
+					dnsmessage.SVCParamPort: {0x21, 0x35},
+				},
 			}},
 			InternalDomains: []string{"internal.example"},
 			SearchDomains:   []string{"internal.example", "example"},

--- a/dns.go
+++ b/dns.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"golang.org/x/net/dns/dnsmessage"
 	"golang.org/x/net/idna"
 )
 
@@ -19,8 +20,7 @@ const (
 )
 
 // DNSNameserver describes the Nameserver structure defined by
-// draft-ietf-masque-connect-ip-dns-06. ServiceParameters contains SvcParams
-// in the wire format defined by RFC 9460.
+// draft-ietf-masque-connect-ip-dns-06.
 type DNSNameserver struct {
 	ServicePriority uint16
 	IPv4Addresses   []netip.Addr
@@ -32,7 +32,7 @@ type DNSNameserver struct {
 	// U-labels are rejected. It may be empty only when the nameserver supports
 	// unencrypted DNS exclusively.
 	AuthenticationDomainName string
-	ServiceParameters        []byte
+	ServiceParameters        []dnsmessage.SVCParam
 }
 
 // DNSConfiguration describes the DNS Configuration structure defined by
@@ -79,25 +79,47 @@ func validateDomainName(name string, allowEmpty bool) error {
 }
 
 func (c DNSConfiguration) validate() error {
-	for _, nameserver := range c.Nameservers {
-		if nameserver.ServicePriority == 0 {
+	for _, ns := range c.Nameservers {
+		if ns.ServicePriority == 0 {
 			return errors.New("service priority must not be zero")
 		}
-		if len(nameserver.ServiceParameters) > maxServiceParametersLen {
+		var serviceParametersLen int
+		var hasALPN, hasNoDefaultALPN bool
+		for i, p := range ns.ServiceParameters {
+			if i > 0 && p.Key <= ns.ServiceParameters[i-1].Key {
+				return errors.New("service parameter keys must be in strictly increasing order")
+			}
+			if len(p.Value) > maxServiceParametersLen {
+				return errors.New("service parameter value too long")
+			}
+			serviceParametersLen += 4 + len(p.Value)
+			switch p.Key {
+			case dnsmessage.SVCParamALPN:
+				hasALPN = true
+			case dnsmessage.SVCParamNoDefaultALPN:
+				hasNoDefaultALPN = true
+			case dnsmessage.SVCParamIPv4Hint, dnsmessage.SVCParamIPv6Hint:
+				return fmt.Errorf("service parameter %s is not allowed", p.Key)
+			}
+		}
+		if serviceParametersLen > maxServiceParametersLen {
 			return errors.New("service parameters too long")
 		}
-		if err := validateDomainName(nameserver.AuthenticationDomainName, true); err != nil {
+		if err := validateDomainName(ns.AuthenticationDomainName, true); err != nil {
 			return fmt.Errorf("invalid authentication domain name: %w", err)
 		}
-		if nameserver.AuthenticationDomainName == "" && len(nameserver.IPv4Addresses)+len(nameserver.IPv6Addresses) == 0 {
-			return errors.New("nameserver must have an address when authentication domain name is empty")
+		if ns.AuthenticationDomainName == "" && (hasALPN || hasNoDefaultALPN) {
+			return errors.New("ALPN service parameters require an authentication domain name")
 		}
-		for _, addr := range nameserver.IPv4Addresses {
+		if !hasNoDefaultALPN && len(ns.IPv4Addresses)+len(ns.IPv6Addresses) == 0 {
+			return errors.New("nameserver must have an address when no-default-alpn is omitted")
+		}
+		for _, addr := range ns.IPv4Addresses {
 			if !addr.Is4() {
 				return fmt.Errorf("non-IPv4 address in IPv4 address list: %s", addr)
 			}
 		}
-		for _, addr := range nameserver.IPv6Addresses {
+		for _, addr := range ns.IPv6Addresses {
 			if !addr.Is6() || addr.Is4In6() {
 				return fmt.Errorf("non-IPv6 address in IPv6 address list: %s", addr)
 			}

--- a/dns.go
+++ b/dns.go
@@ -32,7 +32,9 @@ type DNSNameserver struct {
 	// U-labels are rejected. It may be empty only when the nameserver supports
 	// unencrypted DNS exclusively.
 	AuthenticationDomainName string
-	ServiceParameters        []dnsmessage.SVCParam
+	// ServiceParameters is the set of SVCB parameters that apply to this nameserver.
+	// Each map value is the wire-format SvcParamValue for its key.
+	ServiceParameters map[dnsmessage.SVCParamKey][]byte
 }
 
 // DNSConfiguration describes the DNS Configuration structure defined by
@@ -85,21 +87,18 @@ func (c DNSConfiguration) validate() error {
 		}
 		var serviceParametersLen int
 		var hasALPN, hasNoDefaultALPN bool
-		for i, p := range ns.ServiceParameters {
-			if i > 0 && p.Key <= ns.ServiceParameters[i-1].Key {
-				return errors.New("service parameter keys must be in strictly increasing order")
-			}
-			if len(p.Value) > maxServiceParametersLen {
+		for k, v := range ns.ServiceParameters {
+			if len(v) > maxServiceParametersLen {
 				return errors.New("service parameter value too long")
 			}
-			serviceParametersLen += 4 + len(p.Value)
-			switch p.Key {
+			serviceParametersLen += 4 + len(v)
+			switch k {
 			case dnsmessage.SVCParamALPN:
 				hasALPN = true
 			case dnsmessage.SVCParamNoDefaultALPN:
 				hasNoDefaultALPN = true
 			case dnsmessage.SVCParamIPv4Hint, dnsmessage.SVCParamIPv6Hint:
-				return fmt.Errorf("service parameter %s is not allowed", p.Key)
+				return fmt.Errorf("service parameter %s is not allowed", k)
 			}
 		}
 		if serviceParametersLen > maxServiceParametersLen {

--- a/dns_test.go
+++ b/dns_test.go
@@ -155,26 +155,28 @@ func TestDNSConfigurationIPv6ZoneValidation(t *testing.T) {
 }
 
 func TestDNSConfigurationValidServiceParameters(t *testing.T) {
-	alpn := dnsmessage.SVCParam{Key: dnsmessage.SVCParamALPN, Value: []byte{2, 'h', '2', 2, 'h', '3'}}
-	noDefaultALPN := dnsmessage.SVCParam{Key: dnsmessage.SVCParamNoDefaultALPN, Value: []byte{}}
+	alpn := []byte{2, 'h', '2', 2, 'h', '3'}
 	tests := []struct {
 		name              string
-		serviceParameters []dnsmessage.SVCParam
+		serviceParameters map[dnsmessage.SVCParamKey][]byte
 	}{
 		{
-			name:              "encrypted DNS without an address",
-			serviceParameters: []dnsmessage.SVCParam{alpn, noDefaultALPN},
+			name: "encrypted DNS without an address",
+			serviceParameters: map[dnsmessage.SVCParamKey][]byte{
+				dnsmessage.SVCParamALPN:          alpn,
+				dnsmessage.SVCParamNoDefaultALPN: {},
+			},
 		},
 		{
 			name: "opaque no-default-alpn value",
-			serviceParameters: []dnsmessage.SVCParam{
-				alpn,
-				{Key: dnsmessage.SVCParamNoDefaultALPN, Value: []byte{1}},
+			serviceParameters: map[dnsmessage.SVCParamKey][]byte{
+				dnsmessage.SVCParamALPN:          alpn,
+				dnsmessage.SVCParamNoDefaultALPN: {1},
 			},
 		},
 		{
 			name:              "no-default-alpn without ALPN",
-			serviceParameters: []dnsmessage.SVCParam{noDefaultALPN},
+			serviceParameters: map[dnsmessage.SVCParamKey][]byte{dnsmessage.SVCParamNoDefaultALPN: {}},
 		},
 	}
 
@@ -191,48 +193,38 @@ func TestDNSConfigurationValidServiceParameters(t *testing.T) {
 }
 
 func TestDNSConfigurationInvalidServiceParameters(t *testing.T) {
-	alpn := dnsmessage.SVCParam{Key: dnsmessage.SVCParamALPN, Value: []byte{2, 'h', '2', 2, 'h', '3'}}
+	alpn := []byte{2, 'h', '2', 2, 'h', '3'}
 	tests := []struct {
 		name                     string
 		authenticationDomainName string
 		ipv4Addresses            []netip.Addr
-		serviceParameters        []dnsmessage.SVCParam
+		serviceParameters        map[dnsmessage.SVCParamKey][]byte
 		err                      string
 	}{
 		{
-			name:                     "unordered keys",
-			authenticationDomainName: "resolver.example",
-			serviceParameters: []dnsmessage.SVCParam{
-				{Key: dnsmessage.SVCParamPort},
-				alpn,
-			},
-			err: "strictly increasing order",
-		},
-		{
 			name:                     "parameters too long",
 			authenticationDomainName: "resolver.example",
-			serviceParameters: []dnsmessage.SVCParam{{
-				Key:   dnsmessage.SVCParamPort,
-				Value: make([]byte, maxServiceParametersLen),
-			}},
+			serviceParameters: map[dnsmessage.SVCParamKey][]byte{
+				dnsmessage.SVCParamPort: make([]byte, maxServiceParametersLen),
+			},
 			err: "service parameters too long",
 		},
 		{
 			name:                     "IPv4 hint",
 			authenticationDomainName: "resolver.example",
-			serviceParameters:        []dnsmessage.SVCParam{{Key: dnsmessage.SVCParamIPv4Hint}},
+			serviceParameters:        map[dnsmessage.SVCParamKey][]byte{dnsmessage.SVCParamIPv4Hint: nil},
 			err:                      "service parameter IPv4Hint is not allowed",
 		},
 		{
 			name:                     "IPv6 hint",
 			authenticationDomainName: "resolver.example",
-			serviceParameters:        []dnsmessage.SVCParam{{Key: dnsmessage.SVCParamIPv6Hint}},
+			serviceParameters:        map[dnsmessage.SVCParamKey][]byte{dnsmessage.SVCParamIPv6Hint: nil},
 			err:                      "service parameter IPv6Hint is not allowed",
 		},
 		{
 			name:              "ALPN without authentication domain name",
 			ipv4Addresses:     []netip.Addr{netip.MustParseAddr("192.0.2.53")},
-			serviceParameters: []dnsmessage.SVCParam{alpn},
+			serviceParameters: map[dnsmessage.SVCParamKey][]byte{dnsmessage.SVCParamALPN: alpn},
 			err:               "ALPN service parameters require an authentication domain name",
 		},
 		{

--- a/dns_test.go
+++ b/dns_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/dns/dnsmessage"
 )
 
 func TestDNSConfigurationDomainValidation(t *testing.T) {
@@ -19,6 +20,7 @@ func TestDNSConfigurationDomainValidation(t *testing.T) {
 			configuration: DNSConfiguration{
 				Nameservers: []DNSNameserver{{
 					ServicePriority:          1,
+					IPv4Addresses:            []netip.Addr{netip.MustParseAddr("192.0.2.53")},
 					AuthenticationDomainName: "xn--bcher-kva.example",
 				}},
 				InternalDomains: []string{"xn--bcher-kva.internal.example"},
@@ -150,4 +152,105 @@ func TestDNSConfigurationIPv6ZoneValidation(t *testing.T) {
 		}}}
 		require.ErrorContains(t, configuration.validate(), "IPv6 address with zone")
 	})
+}
+
+func TestDNSConfigurationValidServiceParameters(t *testing.T) {
+	alpn := dnsmessage.SVCParam{Key: dnsmessage.SVCParamALPN, Value: []byte{2, 'h', '2', 2, 'h', '3'}}
+	noDefaultALPN := dnsmessage.SVCParam{Key: dnsmessage.SVCParamNoDefaultALPN, Value: []byte{}}
+	tests := []struct {
+		name              string
+		serviceParameters []dnsmessage.SVCParam
+	}{
+		{
+			name:              "encrypted DNS without an address",
+			serviceParameters: []dnsmessage.SVCParam{alpn, noDefaultALPN},
+		},
+		{
+			name: "opaque no-default-alpn value",
+			serviceParameters: []dnsmessage.SVCParam{
+				alpn,
+				{Key: dnsmessage.SVCParamNoDefaultALPN, Value: []byte{1}},
+			},
+		},
+		{
+			name:              "no-default-alpn without ALPN",
+			serviceParameters: []dnsmessage.SVCParam{noDefaultALPN},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			configuration := DNSConfiguration{Nameservers: []DNSNameserver{{
+				ServicePriority:          1,
+				AuthenticationDomainName: "resolver.example",
+				ServiceParameters:        test.serviceParameters,
+			}}}
+			require.NoError(t, configuration.validate())
+		})
+	}
+}
+
+func TestDNSConfigurationInvalidServiceParameters(t *testing.T) {
+	alpn := dnsmessage.SVCParam{Key: dnsmessage.SVCParamALPN, Value: []byte{2, 'h', '2', 2, 'h', '3'}}
+	tests := []struct {
+		name                     string
+		authenticationDomainName string
+		ipv4Addresses            []netip.Addr
+		serviceParameters        []dnsmessage.SVCParam
+		err                      string
+	}{
+		{
+			name:                     "unordered keys",
+			authenticationDomainName: "resolver.example",
+			serviceParameters: []dnsmessage.SVCParam{
+				{Key: dnsmessage.SVCParamPort},
+				alpn,
+			},
+			err: "strictly increasing order",
+		},
+		{
+			name:                     "parameters too long",
+			authenticationDomainName: "resolver.example",
+			serviceParameters: []dnsmessage.SVCParam{{
+				Key:   dnsmessage.SVCParamPort,
+				Value: make([]byte, maxServiceParametersLen),
+			}},
+			err: "service parameters too long",
+		},
+		{
+			name:                     "IPv4 hint",
+			authenticationDomainName: "resolver.example",
+			serviceParameters:        []dnsmessage.SVCParam{{Key: dnsmessage.SVCParamIPv4Hint}},
+			err:                      "service parameter IPv4Hint is not allowed",
+		},
+		{
+			name:                     "IPv6 hint",
+			authenticationDomainName: "resolver.example",
+			serviceParameters:        []dnsmessage.SVCParam{{Key: dnsmessage.SVCParamIPv6Hint}},
+			err:                      "service parameter IPv6Hint is not allowed",
+		},
+		{
+			name:              "ALPN without authentication domain name",
+			ipv4Addresses:     []netip.Addr{netip.MustParseAddr("192.0.2.53")},
+			serviceParameters: []dnsmessage.SVCParam{alpn},
+			err:               "ALPN service parameters require an authentication domain name",
+		},
+		{
+			name:                     "unencrypted DNS without an address",
+			authenticationDomainName: "resolver.example",
+			err:                      "nameserver must have an address when no-default-alpn is omitted",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			configuration := DNSConfiguration{Nameservers: []DNSNameserver{{
+				ServicePriority:          1,
+				IPv4Addresses:            test.ipv4Addresses,
+				AuthenticationDomainName: test.authenticationDomainName,
+				ServiceParameters:        test.serviceParameters,
+			}}}
+			require.ErrorContains(t, configuration.validate(), test.err)
+		})
+	}
 }


### PR DESCRIPTION
We intentionally only do the verification required by the DNS/PREF64 draft. We *do not* validate the format of the service parameter value.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Parse and validate service parameters in `DNS_ASSIGN` capsule
- Changes `DNSNameserver.ServiceParameters` from a raw `[]byte` to `[]dnsmessage.SVCParam`; the capsule parser decodes each key/length/value tuple into a typed record and the serializer re-encodes them to wire format.
- `DNSConfiguration.validate` now enforces strictly increasing service-parameter keys, per-value and total encoded size limits, and rejects IPv4 and IPv6 hint parameters.
- ALPN or no-default-alpn parameters require a non-empty authentication domain name; addressless nameservers are allowed only when no-default-alpn is present, otherwise at least one address is required.
- Behavioral Change: `DNSNameserver.ServiceParameters` is now a structured slice — all callers in [dns.go](https://github.com/quic-go/connect-ip-go/pull/80/files#diff-cb1b8a01bbc5f64cf06dce0e3f8021ad8289078b402dc620afa04780484d7cd5), [capsule.go](https://github.com/quic-go/connect-ip-go/pull/80/files#diff-fcb26645ce598638fca6816e1387f7465294a2b2becbbeec6fb2128e303ab5e6), and [conn_test.go](https://github.com/quic-go/connect-ip-go/pull/80/files#diff-e23b4ab1f834694782fc82e170f513556a61155002e760c071fd1184407455ab) are updated, but out-of-tree consumers supplying raw wire bytes will break.

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized bedde6c. 2 files reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>

### 🗂️ Filtered Issues

</details><!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - DNS nameserver configurations support structured service parameters, including port, ALPN, and no-default-alpn settings.
  - Service parameters are serialized in a consistent, deterministic order.

- **Bug Fixes**
  - Improved validation rejects duplicate, oversized, unsupported, or malformed service parameters.
  - Invalid combinations involving address hints, authentication domains, and missing DNS addresses are now rejected with clearer validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->