### PR TITLE
enforce FQDN requirement on all domains sent in DNS_ASSIGN

### DIFF
--- a/capsule_test.go
+++ b/capsule_test.go
@@ -308,15 +308,15 @@ func TestParseDNSAssignCapsule(t *testing.T) {
 	payload = append(payload, netip.MustParseAddr("192.0.2.33").AsSlice()...)
 	payload = quicvarint.Append(payload, 1) // IPv6 Address Count
 	payload = append(payload, netip.MustParseAddr("2001:db8::1").AsSlice()...)
-	payload = appendDomain(payload, "resolver.example")
+	payload = appendDomain(payload, "resolver.example.")
 	serviceParametersBytes := []byte{0, 3, 0, 2, 0x21, 0x35} // port=853
 	payload = quicvarint.Append(payload, uint64(len(serviceParametersBytes)))
 	payload = append(payload, serviceParametersBytes...)
 	payload = quicvarint.Append(payload, 1) // Internal Domain Count
-	payload = appendDomain(payload, "internal.example")
+	payload = appendDomain(payload, "internal.example.")
 	payload = quicvarint.Append(payload, 2) // Search Domain Count
-	payload = appendDomain(payload, "internal.example")
-	payload = appendDomain(payload, "example")
+	payload = appendDomain(payload, "internal.example.")
+	payload = appendDomain(payload, "example.")
 
 	// A DNS_ASSIGN capsule can carry another configuration for a different
 	// internal domain.
@@ -328,7 +328,7 @@ func TestParseDNSAssignCapsule(t *testing.T) {
 	payload = appendDomain(payload, "")
 	payload = quicvarint.Append(payload, 0) // Service Parameters Length
 	payload = quicvarint.Append(payload, 1)
-	payload = appendDomain(payload, "other.example")
+	payload = appendDomain(payload, "other.example.")
 	payload = quicvarint.Append(payload, 0)
 
 	capsule, err := parseDNSAssignCapsule(newCapsuleReader(t, capsuleTypeDNSAssign, payload))
@@ -340,13 +340,13 @@ func TestParseDNSAssignCapsule(t *testing.T) {
 					ServicePriority:          42,
 					IPv4Addresses:            []netip.Addr{netip.MustParseAddr("192.0.2.33")},
 					IPv6Addresses:            []netip.Addr{netip.MustParseAddr("2001:db8::1")},
-					AuthenticationDomainName: "resolver.example",
+					AuthenticationDomainName: "resolver.example.",
 					ServiceParameters: map[dnsmessage.SVCParamKey][]byte{
 						dnsmessage.SVCParamPort: {0x21, 0x35},
 					},
 				}},
-				InternalDomains: []string{"internal.example"},
-				SearchDomains:   []string{"internal.example", "example"},
+				InternalDomains: []string{"internal.example."},
+				SearchDomains:   []string{"internal.example.", "example."},
 			},
 			{
 				Nameservers: []DNSNameserver{{
@@ -354,7 +354,7 @@ func TestParseDNSAssignCapsule(t *testing.T) {
 					IPv4Addresses:            []netip.Addr{netip.MustParseAddr("198.51.100.53")},
 					AuthenticationDomainName: "",
 				}},
-				InternalDomains: []string{"other.example"},
+				InternalDomains: []string{"other.example."},
 			},
 		},
 	}, capsule)
@@ -365,7 +365,7 @@ func TestWriteDNSAssignCapsule(t *testing.T) {
 		{
 			Nameservers: []DNSNameserver{{
 				ServicePriority:          1,
-				AuthenticationDomainName: "masque.example.org",
+				AuthenticationDomainName: "masque.example.org.",
 				ServiceParameters: map[dnsmessage.SVCParamKey][]byte{
 					dnsmessage.SVCParamNoDefaultALPN: {},
 					dnsmessage.SVCParamALPN:          {2, 'h', '3'},
@@ -378,8 +378,8 @@ func TestWriteDNSAssignCapsule(t *testing.T) {
 				ServicePriority: 2,
 				IPv4Addresses:   []netip.Addr{netip.MustParseAddr("192.0.2.53")},
 			}},
-			InternalDomains: []string{"internal.example"},
-			SearchDomains:   []string{"internal.example", "XN--BCHER-KVA.example"},
+			InternalDomains: []string{"internal.example."},
+			SearchDomains:   []string{"internal.example.", "XN--BCHER-KVA.example."},
 		},
 	}}
 
@@ -397,7 +397,7 @@ func TestWriteDNSAssignCapsuleSortsServiceParameters(t *testing.T) {
 	capsule := &dnsAssignCapsule{DNSConfigurations: []DNSConfiguration{{
 		Nameservers: []DNSNameserver{{
 			ServicePriority:          1,
-			AuthenticationDomainName: "resolver.example",
+			AuthenticationDomainName: "resolver.example.",
 			ServiceParameters: map[dnsmessage.SVCParamKey][]byte{
 				dnsmessage.SVCParamPort:          {0, 53},
 				dnsmessage.SVCParamNoDefaultALPN: {},
@@ -410,7 +410,7 @@ func TestWriteDNSAssignCapsuleSortsServiceParameters(t *testing.T) {
 	payload = binary.BigEndian.AppendUint16(payload, 1)
 	payload = quicvarint.Append(payload, 0) // IPv4 Address Count
 	payload = quicvarint.Append(payload, 0) // IPv6 Address Count
-	payload = appendDomain(payload, "resolver.example")
+	payload = appendDomain(payload, "resolver.example.")
 	payload = quicvarint.Append(payload, 17) // Service Parameters Length
 	payload = append(payload, 0, 1, 0, 3, 2, 'h', '3')
 	payload = append(payload, 0, 2, 0, 0)
@@ -468,7 +468,7 @@ func TestParseDNSAssignCapsuleInvalid(t *testing.T) {
 	t.Run("domain must use A-label form", func(t *testing.T) {
 		payload := quicvarint.Append(nil, 0) // Nameserver Count
 		payload = quicvarint.Append(payload, 1)
-		payload = appendDomain(payload, "bücher.example")
+		payload = appendDomain(payload, "bücher.example.")
 		payload = quicvarint.Append(payload, 0)
 
 		_, err := parseDNSAssignCapsule(newCapsuleReader(t, capsuleTypeDNSAssign, payload))
@@ -507,7 +507,7 @@ func TestParseDNSAssignCapsuleInvalid(t *testing.T) {
 		payload = binary.BigEndian.AppendUint16(payload, 1)
 		payload = quicvarint.Append(payload, 0) // IPv4 Address Count
 		payload = quicvarint.Append(payload, 0) // IPv6 Address Count
-		payload = appendDomain(payload, "resolver.example")
+		payload = appendDomain(payload, "resolver.example.")
 		payload = quicvarint.Append(payload, 5)
 		payload = append(payload, 0, 3, 0, 2, 0x21)
 		payload = quicvarint.Append(payload, 0)
@@ -522,7 +522,7 @@ func TestParseDNSAssignCapsuleInvalid(t *testing.T) {
 		payload = binary.BigEndian.AppendUint16(payload, 1)
 		payload = quicvarint.Append(payload, 0) // IPv4 Address Count
 		payload = quicvarint.Append(payload, 0) // IPv6 Address Count
-		payload = appendDomain(payload, "resolver.example")
+		payload = appendDomain(payload, "resolver.example.")
 		payload = quicvarint.Append(payload, 8)
 		payload = append(payload, 0, 3, 0, 0, 0, 1, 0, 0)
 		payload = quicvarint.Append(payload, 0)
@@ -537,7 +537,7 @@ func TestParseDNSAssignCapsuleInvalid(t *testing.T) {
 		payload = binary.BigEndian.AppendUint16(payload, 1)
 		payload = quicvarint.Append(payload, 0) // IPv4 Address Count
 		payload = quicvarint.Append(payload, 0) // IPv6 Address Count
-		payload = appendDomain(payload, "resolver.example")
+		payload = appendDomain(payload, "resolver.example.")
 		payload = quicvarint.Append(payload, 8)
 		payload = append(payload, 0, 3, 0, 0, 0, 3, 0, 0)
 		payload = quicvarint.Append(payload, 0)
@@ -554,20 +554,20 @@ func TestParseDNSAssignCapsuleInvalid(t *testing.T) {
 					ServicePriority:          1,
 					IPv4Addresses:            []netip.Addr{netip.MustParseAddr("192.0.2.53")},
 					IPv6Addresses:            []netip.Addr{netip.MustParseAddr("2001:db8::53")},
-					AuthenticationDomainName: "resolver.example",
+					AuthenticationDomainName: "resolver.example.",
 					ServiceParameters: map[dnsmessage.SVCParamKey][]byte{
 						dnsmessage.SVCParamPort: {0x21, 0x35},
 					},
 				}},
-				InternalDomains: []string{"internal.example"},
-				SearchDomains:   []string{"internal.example", "example"},
+				InternalDomains: []string{"internal.example."},
+				SearchDomains:   []string{"internal.example.", "example."},
 			},
 			{
 				Nameservers: []DNSNameserver{{
 					ServicePriority: 2,
 					IPv4Addresses:   []netip.Addr{netip.MustParseAddr("198.51.100.53")},
 				}},
-				InternalDomains: []string{"other.example"},
+				InternalDomains: []string{"other.example."},
 			},
 		}}).append(nil)
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -101,20 +101,20 @@ func TestDNSConfiguration(t *testing.T) {
 				ServicePriority:          1,
 				IPv4Addresses:            []netip.Addr{netip.MustParseAddr("192.0.2.53")},
 				IPv6Addresses:            []netip.Addr{netip.MustParseAddr("2001:db8::53")},
-				AuthenticationDomainName: "resolver.example",
+				AuthenticationDomainName: "resolver.example.",
 				ServiceParameters: map[dnsmessage.SVCParamKey][]byte{
 					dnsmessage.SVCParamPort: {0x21, 0x35},
 				},
 			}},
-			InternalDomains: []string{"internal.example"},
-			SearchDomains:   []string{"internal.example", "example"},
+			InternalDomains: []string{"internal.example."},
+			SearchDomains:   []string{"internal.example.", "example."},
 		},
 		{
 			Nameservers: []DNSNameserver{{
 				ServicePriority: 2,
 				IPv4Addresses:   []netip.Addr{netip.MustParseAddr("198.51.100.53")},
 			}},
-			InternalDomains: []string{"other.example"},
+			InternalDomains: []string{"other.example."},
 		},
 	}
 
@@ -176,7 +176,7 @@ func TestDNSConfiguration(t *testing.T) {
 		require.ErrorContains(t,
 			conn.SendDNSConfiguration([]DNSConfiguration{
 				{
-					InternalDomains: []string{"bücher.example"},
+					InternalDomains: []string{"bücher.example."},
 				},
 			}),
 			"invalid internal domain name: must use IDNA A-label form",

--- a/dns.go
+++ b/dns.go
@@ -28,9 +28,9 @@ type DNSNameserver struct {
 	// Zone identifiers are local to an endpoint and are not part of the wire format.
 	IPv6Addresses []netip.Addr
 	// AuthenticationDomainName is the fully qualified domain name of the
-	// nameserver. It must be in DNS presentation format using IDNA A-labels;
-	// U-labels are rejected. It may be empty only when the nameserver supports
-	// unencrypted DNS exclusively.
+	// nameserver. It must be in DNS presentation format, including the terminating
+	// root dot, and use IDNA A-labels; U-labels are rejected. It may be empty only
+	// when the nameserver supports unencrypted DNS exclusively.
 	AuthenticationDomainName string
 	// ServiceParameters is the set of SVCB parameters that apply to this nameserver.
 	// Each map value is the wire-format SvcParamValue for its key.
@@ -42,11 +42,12 @@ type DNSNameserver struct {
 type DNSConfiguration struct {
 	Nameservers []DNSNameserver
 	// InternalDomains contains fully qualified domain names in DNS presentation
-	// format using IDNA A-labels. U-labels are rejected. An empty string
-	// represents the DNS root.
+	// format, including the terminating root dot, using IDNA A-labels. U-labels
+	// are rejected. An empty string represents the DNS root.
 	InternalDomains []string
 	// SearchDomains contains fully qualified domain names in DNS presentation
-	// format using IDNA A-labels. U-labels and empty strings are rejected.
+	// format, including the terminating root dot, using IDNA A-labels. U-labels
+	// and empty strings are rejected.
 	SearchDomains []string
 }
 
@@ -69,7 +70,10 @@ func validateDomainName(name string, allowEmpty bool) error {
 			return errors.New("must use IDNA A-label form")
 		}
 	}
-	name = strings.TrimSuffix(name, ".")
+	name, ok := strings.CutSuffix(name, ".")
+	if !ok {
+		return errors.New("must be fully qualified (end with a dot)")
+	}
 	ascii, err := dnsNameProfile.ToASCII(name)
 	if err != nil {
 		return fmt.Errorf("must be a valid IDNA A-label: %w", err)

--- a/dns.go
+++ b/dns.go
@@ -72,7 +72,7 @@ func validateDomainName(name string, allowEmpty bool) error {
 	}
 	name, ok := strings.CutSuffix(name, ".")
 	if !ok {
-		return errors.New("must be fully qualified (end with a dot)")
+		return errors.New("must be an FQDN")
 	}
 	ascii, err := dnsNameProfile.ToASCII(name)
 	if err != nil {

--- a/dns_test.go
+++ b/dns_test.go
@@ -72,26 +72,26 @@ func TestDNSConfigurationDomainValidation(t *testing.T) {
 			err: "invalid search domain name: must use IDNA A-label form",
 		},
 		{
-			name: "authentication domain must be fully qualified",
+			name: "authentication domain must be an FQDN",
 			configuration: DNSConfiguration{Nameservers: []DNSNameserver{{
 				ServicePriority:          1,
 				AuthenticationDomainName: "resolver.example",
 			}}},
-			err: "invalid authentication domain name: must be fully qualified",
+			err: "invalid authentication domain name: must be an FQDN",
 		},
 		{
-			name: "internal domain must be fully qualified",
+			name: "internal domain must be an FQDN",
 			configuration: DNSConfiguration{
 				InternalDomains: []string{"internal.example"},
 			},
-			err: "invalid internal domain name: must be fully qualified",
+			err: "invalid internal domain name: must be an FQDN",
 		},
 		{
-			name: "search domain must be fully qualified",
+			name: "search domain must be an FQDN",
 			configuration: DNSConfiguration{
 				SearchDomains: []string{"example"},
 			},
-			err: "invalid search domain name: must be fully qualified",
+			err: "invalid search domain name: must be an FQDN",
 		},
 		{
 			name: "empty search domain",

--- a/dns_test.go
+++ b/dns_test.go
@@ -21,10 +21,10 @@ func TestDNSConfigurationDomainValidation(t *testing.T) {
 				Nameservers: []DNSNameserver{{
 					ServicePriority:          1,
 					IPv4Addresses:            []netip.Addr{netip.MustParseAddr("192.0.2.53")},
-					AuthenticationDomainName: "xn--bcher-kva.example",
+					AuthenticationDomainName: "xn--bcher-kva.example.",
 				}},
-				InternalDomains: []string{"xn--bcher-kva.internal.example"},
-				SearchDomains:   []string{"XN--BCHER-KVA.example"},
+				InternalDomains: []string{"xn--bcher-kva.internal.example."},
+				SearchDomains:   []string{"XN--BCHER-KVA.example."},
 			},
 		},
 		{
@@ -40,7 +40,7 @@ func TestDNSConfigurationDomainValidation(t *testing.T) {
 		{
 			name: "underscore label",
 			configuration: DNSConfiguration{
-				SearchDomains: []string{"_msdcs.corp.example"},
+				SearchDomains: []string{"_msdcs.corp.example."},
 			},
 		},
 		{
@@ -53,23 +53,45 @@ func TestDNSConfigurationDomainValidation(t *testing.T) {
 			name: "authentication U-label",
 			configuration: DNSConfiguration{Nameservers: []DNSNameserver{{
 				ServicePriority:          1,
-				AuthenticationDomainName: "bücher.example",
+				AuthenticationDomainName: "bücher.example.",
 			}}},
 			err: "invalid authentication domain name: must use IDNA A-label form",
 		},
 		{
 			name: "internal U-label",
 			configuration: DNSConfiguration{
-				InternalDomains: []string{"bücher.example"},
+				InternalDomains: []string{"bücher.example."},
 			},
 			err: "invalid internal domain name: must use IDNA A-label form",
 		},
 		{
 			name: "search U-label",
 			configuration: DNSConfiguration{
-				SearchDomains: []string{"bücher.example"},
+				SearchDomains: []string{"bücher.example."},
 			},
 			err: "invalid search domain name: must use IDNA A-label form",
+		},
+		{
+			name: "authentication domain must be fully qualified",
+			configuration: DNSConfiguration{Nameservers: []DNSNameserver{{
+				ServicePriority:          1,
+				AuthenticationDomainName: "resolver.example",
+			}}},
+			err: "invalid authentication domain name: must be fully qualified",
+		},
+		{
+			name: "internal domain must be fully qualified",
+			configuration: DNSConfiguration{
+				InternalDomains: []string{"internal.example"},
+			},
+			err: "invalid internal domain name: must be fully qualified",
+		},
+		{
+			name: "search domain must be fully qualified",
+			configuration: DNSConfiguration{
+				SearchDomains: []string{"example"},
+			},
+			err: "invalid search domain name: must be fully qualified",
 		},
 		{
 			name: "empty search domain",
@@ -81,21 +103,21 @@ func TestDNSConfigurationDomainValidation(t *testing.T) {
 		{
 			name: "invalid A-label",
 			configuration: DNSConfiguration{
-				SearchDomains: []string{"xn--.example"},
+				SearchDomains: []string{"xn--.example."},
 			},
 			err: "invalid search domain name: must be a valid IDNA A-label",
 		},
 		{
 			name: "leading hyphen",
 			configuration: DNSConfiguration{
-				SearchDomains: []string{"-resolver.example"},
+				SearchDomains: []string{"-resolver.example."},
 			},
 			err: "invalid search domain name: must be a valid IDNA A-label",
 		},
 		{
 			name: "label too long",
 			configuration: DNSConfiguration{
-				SearchDomains: []string{strings.Repeat("a", 64) + ".example"},
+				SearchDomains: []string{strings.Repeat("a", 64) + ".example."},
 			},
 			err: "invalid search domain name: must be a valid IDNA A-label",
 		},
@@ -184,7 +206,7 @@ func TestDNSConfigurationValidServiceParameters(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			configuration := DNSConfiguration{Nameservers: []DNSNameserver{{
 				ServicePriority:          1,
-				AuthenticationDomainName: "resolver.example",
+				AuthenticationDomainName: "resolver.example.",
 				ServiceParameters:        test.serviceParameters,
 			}}}
 			require.NoError(t, configuration.validate())
@@ -203,7 +225,7 @@ func TestDNSConfigurationInvalidServiceParameters(t *testing.T) {
 	}{
 		{
 			name:                     "parameters too long",
-			authenticationDomainName: "resolver.example",
+			authenticationDomainName: "resolver.example.",
 			serviceParameters: map[dnsmessage.SVCParamKey][]byte{
 				dnsmessage.SVCParamPort: make([]byte, maxServiceParametersLen),
 			},
@@ -211,13 +233,13 @@ func TestDNSConfigurationInvalidServiceParameters(t *testing.T) {
 		},
 		{
 			name:                     "IPv4 hint",
-			authenticationDomainName: "resolver.example",
+			authenticationDomainName: "resolver.example.",
 			serviceParameters:        map[dnsmessage.SVCParamKey][]byte{dnsmessage.SVCParamIPv4Hint: nil},
 			err:                      "service parameter IPv4Hint is not allowed",
 		},
 		{
 			name:                     "IPv6 hint",
-			authenticationDomainName: "resolver.example",
+			authenticationDomainName: "resolver.example.",
 			serviceParameters:        map[dnsmessage.SVCParamKey][]byte{dnsmessage.SVCParamIPv6Hint: nil},
 			err:                      "service parameter IPv6Hint is not allowed",
 		},
@@ -229,7 +251,7 @@ func TestDNSConfigurationInvalidServiceParameters(t *testing.T) {
 		},
 		{
 			name:                     "unencrypted DNS without an address",
-			authenticationDomainName: "resolver.example",
+			authenticationDomainName: "resolver.example.",
 			err:                      "nameserver must have an address when no-default-alpn is omitted",
 		},
 	}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce FQDN requirement on `DNS_ASSIGN` domains via `validateDomainName`
> - Updates `validateDomainName` in [dns.go](https://github.com/quic-go/connect-ip-go/pull/81/files#diff-cb1b8a01bbc5f64cf06dce0e3f8021ad8289078b402dc620afa04780484d7cd5) to reject nonempty authentication, internal, and search domain names that lack a terminating root dot.
> - Updates documentation on `AuthenticationDomainName`, `InternalDomains`, and `SearchDomains` to state the FQDN requirement.
> - Updates parser, writer, connection, and validation tests to use and expect fully qualified domain names.
> - Behavioral Change: `validateDomainName` now rejects previously accepted nonempty domain names without a trailing dot, returning an FQDN validation error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 96fbf29.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - DNS configuration now consistently requires fully qualified domain names with a trailing dot.
  - Domain names without the terminating dot are rejected with a clear validation error.
  - DNS domain validation and capsule handling consistently support the documented IDNA A-label format.

- **Tests**
  - Expanded DNS configuration and capsule coverage for fully qualified domains.
  - Added coverage for service-parameter ordering, truncated values, unordered entries, duplicates, and other invalid cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->