### PR TITLE
limit entries in received address and route capsules

### DIFF
--- a/capsule.go
+++ b/capsule.go
@@ -24,6 +24,12 @@ const (
 	capsuleTypePREF64    http3.CapsuleType = 0x274c0fbc
 )
 
+// Bound the memory used to parse and retain a peer's addresses and routes.
+const (
+	maxAddressesPerCapsule = 8192
+	maxRoutesPerCapsule    = 8192
+)
+
 // addressAssignCapsule represents an ADDRESS_ASSIGN capsule
 type addressAssignCapsule struct {
 	AssignedAddresses []AssignedAddress
@@ -54,14 +60,14 @@ func (r RequestedAddress) len() int {
 	return quicvarint.Len(r.RequestID) + 1 + r.IPPrefix.Addr().BitLen()/8 + 1
 }
 
-func parseAddressAssignCapsule(r io.Reader) (*addressAssignCapsule, error) {
+func parseAddressAssignCapsule(r http3.CapsuleReader) (*addressAssignCapsule, error) {
 	var assignedAddresses []AssignedAddress
-	for {
+	for r.Remaining() > 0 {
+		if len(assignedAddresses) >= maxAddressesPerCapsule {
+			return nil, fmt.Errorf("ADDRESS_ASSIGN capsule contains too many addresses (maximum %d)", maxAddressesPerCapsule)
+		}
 		requestID, prefix, err := parseAddress(r)
 		if err != nil {
-			if err == io.EOF {
-				break
-			}
 			return nil, err
 		}
 		assignedAddresses = append(assignedAddresses, AssignedAddress{RequestID: requestID, IPPrefix: prefix})
@@ -91,14 +97,14 @@ func (c *addressAssignCapsule) append(b []byte) []byte {
 	return b
 }
 
-func parseAddressRequestCapsule(r io.Reader) (*addressRequestCapsule, error) {
+func parseAddressRequestCapsule(r http3.CapsuleReader) (*addressRequestCapsule, error) {
 	var requestedAddresses []RequestedAddress
-	for {
+	for r.Remaining() > 0 {
+		if len(requestedAddresses) >= maxAddressesPerCapsule {
+			return nil, fmt.Errorf("ADDRESS_REQUEST capsule contains too many addresses (maximum %d)", maxAddressesPerCapsule)
+		}
 		requestID, prefix, err := parseAddress(r)
 		if err != nil {
-			if err == io.EOF {
-				break
-			}
 			return nil, err
 		}
 		requestedAddresses = append(requestedAddresses, RequestedAddress{RequestID: requestID, IPPrefix: prefix})
@@ -190,14 +196,14 @@ func (r IPRoute) len() int { return 1 + r.StartIP.BitLen()/8 + r.EndIP.BitLen()/
 // this conversion can result in a large number of prefixes.
 func (r IPRoute) Prefixes() []netip.Prefix { return rangeToPrefixes(r.StartIP, r.EndIP) }
 
-func parseRouteAdvertisementCapsule(r io.Reader) (*routeAdvertisementCapsule, error) {
+func parseRouteAdvertisementCapsule(r http3.CapsuleReader) (*routeAdvertisementCapsule, error) {
 	var ranges []IPRoute
-	for {
+	for r.Remaining() > 0 {
+		if len(ranges) >= maxRoutesPerCapsule {
+			return nil, fmt.Errorf("ROUTE_ADVERTISEMENT capsule contains too many routes (maximum %d)", maxRoutesPerCapsule)
+		}
 		ipRange, err := parseIPAddressRange(r)
 		if err != nil {
-			if err == io.EOF {
-				break
-			}
 			return nil, err
 		}
 		ranges = append(ranges, ipRange)

--- a/capsule_test.go
+++ b/capsule_test.go
@@ -48,6 +48,24 @@ func testIncompleteCapsule(t *testing.T, data []byte, parse func(http3.CapsuleRe
 	}
 }
 
+func testCapsuleEntryLimit[T any](t *testing.T, typ http3.CapsuleType, limit int, entry []byte, parse func(http3.CapsuleReader) (*T, error)) {
+	t.Helper()
+	payload := bytes.Repeat(entry, limit)
+	r := newCapsuleReader(t, typ, payload)
+	_, err := parse(r)
+	require.NoError(t, err)
+	require.Zero(t, r.Remaining())
+
+	// Reject as soon as another entry is declared, without waiting for its bytes.
+	data := quicvarint.Append(nil, uint64(typ))
+	data = quicvarint.Append(data, uint64(len(payload)+1))
+	_, r, err = http3.NewCapsuleParser(bytes.NewReader(append(data, payload...))).Next()
+	require.NoError(t, err)
+	_, err = parse(r)
+	require.ErrorContains(t, err, "too many")
+	require.Equal(t, int64(1), r.Remaining())
+}
+
 func TestParseAddressAssignCapsule(t *testing.T) {
 	addr1 := quicvarint.Append(nil, 1337) // Request ID
 	addr1 = append(addr1, 4)              // IPv4
@@ -79,6 +97,11 @@ func TestParseAddressAssignCapsule(t *testing.T) {
 	require.Zero(t, r.Len())
 }
 
+func TestParseAddressAssignCapsuleLimit(t *testing.T) {
+	entry := []byte{1, 4, 192, 0, 2, 1, 32} // Request ID 1, 192.0.2.1/32.
+	testCapsuleEntryLimit(t, capsuleTypeAddressAssign, maxAddressesPerCapsule, entry, parseAddressAssignCapsule)
+}
+
 func TestWriteAddressAssignCapsule(t *testing.T) {
 	c := &addressAssignCapsule{
 		AssignedAddresses: []AssignedAddress{
@@ -98,13 +121,13 @@ func TestWriteAddressAssignCapsule(t *testing.T) {
 }
 
 func TestParseAddressAssignCapsuleInvalid(t *testing.T) {
-	testParseAddressCapsuleInvalid(t, capsuleTypeAddressAssign, func(r io.Reader) error {
-		_, err := parseAddressAssignCapsule(quicvarint.NewReader(r))
+	testParseAddressCapsuleInvalid(t, capsuleTypeAddressAssign, func(r http3.CapsuleReader) error {
+		_, err := parseAddressAssignCapsule(r)
 		return err
 	})
 }
 
-func testParseAddressCapsuleInvalid(t *testing.T, typ http3.CapsuleType, f func(r io.Reader) error) {
+func testParseAddressCapsuleInvalid(t *testing.T, typ http3.CapsuleType, f func(r http3.CapsuleReader) error) {
 	t.Run("invalid IP version", func(t *testing.T) {
 		addr1 := quicvarint.Append(nil, 1337) // Request ID
 		addr1 = append(addr1, 5)              // Invalid IP version (not 4 or 6)
@@ -150,7 +173,7 @@ func testParseAddressCapsuleInvalid(t *testing.T, typ http3.CapsuleType, f func(
 			t.Fatalf("unexpected capsule type: %d", typ)
 		}
 
-		testIncompleteCapsule(t, data, func(r http3.CapsuleReader) error { return f(r) })
+		testIncompleteCapsule(t, data, f)
 	})
 }
 
@@ -184,6 +207,11 @@ func TestParseAddressRequestCapsule(t *testing.T) {
 	require.Zero(t, r.Len())
 }
 
+func TestParseAddressRequestCapsuleLimit(t *testing.T) {
+	entry := []byte{1, 4, 192, 0, 2, 1, 32} // Request ID 1, 192.0.2.1/32.
+	testCapsuleEntryLimit(t, capsuleTypeAddressRequest, maxAddressesPerCapsule, entry, parseAddressRequestCapsule)
+}
+
 func TestWriteAddressRequestCapsule(t *testing.T) {
 	c := &addressRequestCapsule{
 		RequestedAddresses: []RequestedAddress{
@@ -203,8 +231,8 @@ func TestWriteAddressRequestCapsule(t *testing.T) {
 }
 
 func TestParseAddressRequestCapsuleInvalid(t *testing.T) {
-	testParseAddressCapsuleInvalid(t, capsuleTypeAddressRequest, func(r io.Reader) error {
-		_, err := parseAddressRequestCapsule(quicvarint.NewReader(r))
+	testParseAddressCapsuleInvalid(t, capsuleTypeAddressRequest, func(r http3.CapsuleReader) error {
+		_, err := parseAddressRequestCapsule(r)
 		return err
 	})
 }
@@ -246,6 +274,11 @@ func TestParseRouteAdvertisementCapsule(t *testing.T) {
 		capsule.IPAddressRanges[1].Prefixes(),
 	)
 	require.Zero(t, r.Len())
+}
+
+func TestParseRouteAdvertisementCapsuleLimit(t *testing.T) {
+	entry := []byte{4, 192, 0, 2, 1, 192, 0, 2, 1, 0} // 192.0.2.1, all protocols.
+	testCapsuleEntryLimit(t, capsuleTypeRouteAdvertisement, maxRoutesPerCapsule, entry, parseRouteAdvertisementCapsule)
 }
 
 func TestWriteRouteAdvertisementCapsule(t *testing.T) {

--- a/conn.go
+++ b/conn.go
@@ -37,6 +37,7 @@ type http3Stream interface {
 	ReceiveDatagram(context.Context) ([]byte, error)
 	SendDatagram([]byte) error
 	CancelRead(quic.StreamErrorCode)
+	CancelWrite(quic.StreamErrorCode)
 }
 
 var (
@@ -88,14 +89,22 @@ func newProxiedConn(str http3Stream, closeConn func() error) *Conn {
 		closeChan:               make(chan struct{}),
 	}
 	go func() {
-		if err := c.readFromStream(); err != nil {
+		err := c.readFromStream()
+		if err != nil {
 			log.Printf("handling stream failed: %v", err)
-			c.mu.Lock()
-			if c.closeErr == nil {
-				c.closeErr = &CloseError{Remote: true}
-				close(c.closeChan)
-			}
-			c.mu.Unlock()
+		}
+		c.mu.Lock()
+		if c.closeErr == nil {
+			c.closeErr = &CloseError{Remote: true}
+			close(c.closeChan)
+		}
+		c.mu.Unlock()
+		if err != nil {
+			// Abort the session without consuming the remaining capsule payload.
+			c.str.CancelRead(quic.StreamErrorCode(http3.ErrCodeExcessiveLoad))
+			c.str.CancelWrite(quic.StreamErrorCode(http3.ErrCodeExcessiveLoad))
+		} else {
+			c.str.Close()
 		}
 	}()
 	go func() {
@@ -299,10 +308,12 @@ func (c *Conn) Routes(ctx context.Context) ([]IPRoute, error) {
 }
 
 func (c *Conn) readFromStream() error {
-	defer c.str.Close()
 	p := http3.NewCapsuleParser(c.str)
 	for {
 		t, cr, err := p.Next()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Cap ADDRESS_ASSIGN, ADDRESS_REQUEST, and ROUTE_ADVERTISEMENT at 8192 entries.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Limit address and route capsule entries to `8192` and fix proxied conn EOF handling
> - Adds separate `8192`-entry caps for ADDRESS_ASSIGN, ADDRESS_REQUEST, and ROUTE_ADVERTISEMENT capsules in [capsule.go](https://github.com/quic-go/connect-ip-go/pull/85/files#diff-fcb26645ce598638fca6816e1387f7465294a2b2becbbeec6fb2128e303ab5e6). Parsers now read from the HTTP/3 capsule reader's remaining-byte count, enforce the limit before parsing another entry, and return errors for incomplete entries instead of treating EOF as normal termination.
> - Reworks the proxied connection lifecycle in [conn.go](https://github.com/quic-go/connect-ip-go/pull/85/files#diff-4f427d2b022907c552328e63f137561f6de92396d7a6e8f6c2ea1bcf0db52654) so clean end-of-stream closes the stream normally, while read errors cancel both stream directions with the excessive-load error. `Conn.readFromStream` no longer closes the stream itself; its caller handles closure or cancellation based on the returned result.
> - Risk: capsule parsers now reject trailing partial entries that were previously silently truncated; callers relying on lenient parsing of malformed capsules will see errors instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 64bd228.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added safeguards that reject address and route capsules containing more than 8,192 entries.
  - Improved capsule parsing to handle incomplete or excess data more reliably.
  - Improved HTTP/3 stream error handling: clean closures are handled normally, while stream failures now properly cancel affected communication.
  - Preserved unread data when capsule entry limits are exceeded, enabling more accurate error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->