### PR TITLE
serialize capsule writes and stream close

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -54,21 +54,26 @@ const minMTU = 1280
 // immediately. The queue only grows if the peer falls behind processing the stream.
 const maxQueuedCapsules = 128
 
+type streamWrite struct {
+	Data []byte
+	Fin  bool
+}
+
 // Conn is a connection that proxies IP packets over HTTP/3.
 type Conn struct {
 	str         http3Stream
 	closeConn   func() error
 	writeNotify chan struct{}
+	writeDone   chan struct{}
+	writeErr    error // set before writeDone is closed
 
 	assignedAddressUpdates  chan []netip.Prefix
 	availableRouteUpdates   chan []IPRoute
 	dnsConfigurationUpdates chan []DNSConfiguration
 	pref64Updates           chan []netip.Prefix
 
-	mu sync.Mutex
-	// queuedCapsules contains the capsules serialized by the send methods. This
-	// allows callers to modify the values passed to a send method after it returns.
-	queuedCapsules    [][]byte
+	mu                sync.Mutex
+	queuedWrites      []streamWrite
 	peerAddresses     []netip.Prefix // IP prefixes that we assigned to the peer
 	localRoutes       []IPRoute      // IP routes that we advertised to the peer
 	assignedAddresses []netip.Prefix
@@ -82,6 +87,7 @@ func newProxiedConn(str http3Stream, closeConn func() error) *Conn {
 		str:                     str,
 		closeConn:               closeConn,
 		writeNotify:             make(chan struct{}, 1),
+		writeDone:               make(chan struct{}),
 		assignedAddressUpdates:  make(chan []netip.Prefix, 1),
 		availableRouteUpdates:   make(chan []IPRoute, 1),
 		dnsConfigurationUpdates: make(chan []DNSConfiguration, 1),
@@ -97,26 +103,31 @@ func newProxiedConn(str http3Stream, closeConn func() error) *Conn {
 		if c.closeErr == nil {
 			c.closeErr = &CloseError{Remote: true}
 			close(c.closeChan)
+			if err != nil {
+				// Abort without consuming the remaining capsule payload.
+				c.str.CancelRead(quic.StreamErrorCode(http3.ErrCodeExcessiveLoad))
+				c.str.CancelWrite(quic.StreamErrorCode(http3.ErrCodeExcessiveLoad))
+				close(c.writeNotify)
+			} else {
+				c.queueWrite(streamWrite{Fin: true})
+			}
 		}
 		c.mu.Unlock()
-		if err != nil {
-			// Abort the session without consuming the remaining capsule payload.
-			c.str.CancelRead(quic.StreamErrorCode(http3.ErrCodeExcessiveLoad))
-			c.str.CancelWrite(quic.StreamErrorCode(http3.ErrCodeExcessiveLoad))
-		} else {
-			c.str.Close()
-		}
 	}()
 	go func() {
-		if err := c.writeToStream(); err != nil {
-			log.Printf("writing to stream failed: %v", err)
+		c.writeErr = c.writeToStream()
+		if c.writeErr != nil {
+			log.Printf("writing to stream failed: %v", c.writeErr)
 			c.mu.Lock()
 			if c.closeErr == nil {
 				c.closeErr = &CloseError{Remote: true}
 				close(c.closeChan)
+				c.str.CancelRead(quic.StreamErrorCode(http3.ErrCodeExcessiveLoad))
+				c.str.CancelWrite(quic.StreamErrorCode(http3.ErrCodeExcessiveLoad))
 			}
 			c.mu.Unlock()
 		}
+		close(c.writeDone)
 	}()
 	return c
 }
@@ -137,7 +148,7 @@ func (c *Conn) AdvertiseRoute(routes []IPRoute) error {
 		return err
 	}
 	routes = slices.Clone(routes)
-	err := c.queueCapsule((&routeAdvertisementCapsule{IPAddressRanges: routes}).append(nil))
+	err := c.queueWrite(streamWrite{Data: (&routeAdvertisementCapsule{IPAddressRanges: routes}).append(nil)})
 	if err == nil {
 		c.localRoutes = routes
 	}
@@ -163,7 +174,7 @@ func (c *Conn) AssignAddresses(prefixes []netip.Prefix) error {
 		c.mu.Unlock()
 		return err
 	}
-	err := c.queueCapsule(capsule.append(nil))
+	err := c.queueWrite(streamWrite{Data: capsule.append(nil)})
 	if err == nil {
 		c.peerAddresses = slices.Clone(prefixes)
 	}
@@ -243,7 +254,7 @@ func (c *Conn) sendCapsule(capsuleData []byte) error {
 		c.mu.Unlock()
 		return err
 	}
-	err := c.queueCapsule(capsuleData)
+	err := c.queueWrite(streamWrite{Data: capsuleData})
 	c.mu.Unlock()
 	if err != nil {
 		_ = c.Close()
@@ -252,14 +263,16 @@ func (c *Conn) sendCapsule(capsuleData []byte) error {
 	return nil
 }
 
-func (c *Conn) queueCapsule(capsuleData []byte) error {
-	if len(c.queuedCapsules) >= maxQueuedCapsules {
+func (c *Conn) queueWrite(w streamWrite) error {
+	if !w.Fin && len(c.queuedWrites) >= maxQueuedCapsules {
+		c.closeErr = &CloseError{Remote: false}
+		close(c.closeChan)
+		c.str.CancelRead(quic.StreamErrorCode(http3.ErrCodeExcessiveLoad))
+		c.str.CancelWrite(quic.StreamErrorCode(http3.ErrCodeExcessiveLoad))
+		close(c.writeNotify)
 		return errors.New("connect-ip: capsule queue full")
 	}
-	// Consecutive capsules of the same type could be coalesced here, but that
-	// micro-optimization is not worth the added complexity without evidence.
-	c.queuedCapsules = append(c.queuedCapsules, capsuleData)
-
+	c.queuedWrites = append(c.queuedWrites, w)
 	select {
 	case c.writeNotify <- struct{}{}:
 	default:
@@ -363,33 +376,27 @@ func (c *Conn) readFromStream() error {
 }
 
 func (c *Conn) writeToStream() error {
-	for {
-		select {
-		case <-c.closeChan:
-			return c.closeErr
-		case <-c.writeNotify:
-			for {
-				c.mu.Lock()
-				if c.closeErr != nil {
-					err := c.closeErr
-					c.mu.Unlock()
-					return err
-				}
-				if len(c.queuedCapsules) == 0 {
-					c.mu.Unlock()
-					break
-				}
-				capsuleData := c.queuedCapsules[0]
-				c.queuedCapsules[0] = nil
-				c.queuedCapsules = c.queuedCapsules[1:]
+	for range c.writeNotify {
+		for {
+			c.mu.Lock()
+			if len(c.queuedWrites) == 0 {
 				c.mu.Unlock()
+				break
+			}
+			w := c.queuedWrites[0]
+			c.queuedWrites[0] = streamWrite{}
+			c.queuedWrites = c.queuedWrites[1:]
+			c.mu.Unlock()
 
-				if _, err := c.str.Write(capsuleData); err != nil {
-					return err
-				}
+			if w.Fin {
+				return c.str.Close()
+			}
+			if _, err := c.str.Write(w.Data); err != nil {
+				return err
 			}
 		}
 	}
+	return c.closeErr
 }
 
 func (c *Conn) ReadPacket(b []byte) (n int, err error) {
@@ -555,16 +562,17 @@ func (c *Conn) Close() error {
 	if c.closeErr == nil {
 		c.closeErr = &CloseError{Remote: false}
 		close(c.closeChan)
+		c.queueWrite(streamWrite{Fin: true})
 	}
 	closeConn := c.closeConn
 	c.closeConn = nil
 	c.mu.Unlock()
+	<-c.writeDone
 	c.str.CancelRead(quic.StreamErrorCode(http3.ErrCodeNoError))
-	err := c.str.Close()
 	if closeConn != nil {
-		return errors.Join(err, closeConn())
+		return errors.Join(c.writeErr, closeConn())
 	}
-	return err
+	return c.writeErr
 }
 
 func ipVersion(b []byte) uint8 { return b[0] >> 4 }

--- a/conn.go
+++ b/conn.go
@@ -11,6 +11,7 @@ import (
 	"net/netip"
 	"slices"
 	"sync"
+	"time"
 
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
@@ -38,6 +39,7 @@ type http3Stream interface {
 	SendDatagram([]byte) error
 	CancelRead(quic.StreamErrorCode)
 	CancelWrite(quic.StreamErrorCode)
+	SetWriteDeadline(time.Time) error
 }
 
 var (
@@ -64,8 +66,7 @@ type Conn struct {
 	str         http3Stream
 	closeConn   func() error
 	writeNotify chan struct{}
-	writeDone   chan struct{}
-	writeErr    error // set before writeDone is closed
+	writeDone   chan error
 
 	assignedAddressUpdates  chan []netip.Prefix
 	availableRouteUpdates   chan []IPRoute
@@ -87,7 +88,7 @@ func newProxiedConn(str http3Stream, closeConn func() error) *Conn {
 		str:                     str,
 		closeConn:               closeConn,
 		writeNotify:             make(chan struct{}, 1),
-		writeDone:               make(chan struct{}),
+		writeDone:               make(chan error, 1),
 		assignedAddressUpdates:  make(chan []netip.Prefix, 1),
 		availableRouteUpdates:   make(chan []IPRoute, 1),
 		dnsConfigurationUpdates: make(chan []DNSConfiguration, 1),
@@ -109,24 +110,28 @@ func newProxiedConn(str http3Stream, closeConn func() error) *Conn {
 				c.str.CancelWrite(quic.StreamErrorCode(http3.ErrCodeExcessiveLoad))
 				close(c.writeNotify)
 			} else {
-				c.queueWrite(streamWrite{Fin: true})
+				_ = c.queueWrite(streamWrite{Fin: true})
 			}
 		}
 		c.mu.Unlock()
 	}()
 	go func() {
-		c.writeErr = c.writeToStream()
-		if c.writeErr != nil {
-			log.Printf("writing to stream failed: %v", c.writeErr)
+		err := c.writeToStream()
+		if err != nil {
+			log.Printf("writing to stream failed: %v", err)
 			c.mu.Lock()
 			if c.closeErr == nil {
 				c.closeErr = &CloseError{Remote: true}
 				close(c.closeChan)
 				c.str.CancelRead(quic.StreamErrorCode(http3.ErrCodeExcessiveLoad))
 				c.str.CancelWrite(quic.StreamErrorCode(http3.ErrCodeExcessiveLoad))
+			} else {
+				// A write can time out while graceful shutdown is pending.
+				c.str.CancelWrite(quic.StreamErrorCode(http3.ErrCodeNoError))
 			}
 			c.mu.Unlock()
 		}
+		c.writeDone <- err
 		close(c.writeDone)
 	}()
 	return c
@@ -264,7 +269,10 @@ func (c *Conn) sendCapsule(capsuleData []byte) error {
 }
 
 func (c *Conn) queueWrite(w streamWrite) error {
-	if !w.Fin && len(c.queuedWrites) >= maxQueuedCapsules {
+	if w.Fin {
+		// Interrupt pending capsule writes so shutdown cannot stall.
+		_ = c.str.SetWriteDeadline(time.Now())
+	} else if len(c.queuedWrites) >= maxQueuedCapsules {
 		c.closeErr = &CloseError{Remote: false}
 		close(c.closeChan)
 		c.str.CancelRead(quic.StreamErrorCode(http3.ErrCodeExcessiveLoad))
@@ -272,7 +280,9 @@ func (c *Conn) queueWrite(w streamWrite) error {
 		close(c.writeNotify)
 		return errors.New("connect-ip: capsule queue full")
 	}
+
 	c.queuedWrites = append(c.queuedWrites, w)
+
 	select {
 	case c.writeNotify <- struct{}{}:
 	default:
@@ -562,17 +572,17 @@ func (c *Conn) Close() error {
 	if c.closeErr == nil {
 		c.closeErr = &CloseError{Remote: false}
 		close(c.closeChan)
-		c.queueWrite(streamWrite{Fin: true})
+		_ = c.queueWrite(streamWrite{Fin: true})
 	}
 	closeConn := c.closeConn
 	c.closeConn = nil
 	c.mu.Unlock()
-	<-c.writeDone
+	err := <-c.writeDone
 	c.str.CancelRead(quic.StreamErrorCode(http3.ErrCodeNoError))
 	if closeConn != nil {
-		return errors.Join(c.writeErr, closeConn())
+		return errors.Join(err, closeConn())
 	}
-	return c.writeErr
+	return err
 }
 
 func ipVersion(b []byte) uint8 { return b[0] >> 4 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -87,11 +87,14 @@ func TestCapsuleQueueLimit(t *testing.T) {
 	for range maxQueuedCapsules {
 		require.NoError(t, conn.AssignAddresses(nil))
 	}
+	go func() {
+		_, _ = conn.Routes(context.Background()) // wait for shutdown before releasing the mock writer
+		for range maxQueuedCapsules + 1 {
+			<-writes
+		}
+	}()
 	require.ErrorContains(t, conn.AssignAddresses(nil), "capsule queue full")
 	require.ErrorIs(t, conn.AssignAddresses(nil), net.ErrClosed)
-
-	// Let the writer finish the in-progress write and observe the closed connection.
-	<-writes
 }
 
 func TestDNSConfiguration(t *testing.T) {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Serialize capsule writes and stream close through `writeDone` channel in `Conn`
> - Replaces the capsule byte-slice queue with a unified `streamWrite` queue that carries either capsule data or a FIN marker, so graceful termination flows through the same path as data writes
> - `Conn.Close` now queues a FIN marker (setting an immediate write deadline to interrupt pending writes) and waits for the writer goroutine to finish via the new `writeDone` channel, joining its error with the connection-close error
> - The write goroutine in `writeToStream` drains queued writes on shutdown and closes the stream when it encounters a FIN marker, instead of exiting immediately
> - `TestCapsuleQueueLimit` now waits for shutdown via `Routes` before draining queued writes, verifying the queue-full error while the mock writer is still blocked
> - Behavioral Change: `Conn.Close` no longer calls the stream's `Close` method directly — stream closure is now performed by the writer goroutine when it processes the queued FIN marker in `queueWrite`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f865f5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stream shutdown coordination when read or write operations fail.
  - Ensured successful stream reads are finalized with a proper FIN signal.
  - Improved connection closure by waiting for pending writes and reporting related errors.
  - Added timeout handling during graceful shutdown to prevent blocked writes.
  - Improved handling when the capsule write queue reaches its limit, including stream cancellation and connection closure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->