### PR TITLE
add support for sending and responding to address requests

### DIFF
--- a/address.go
+++ b/address.go
@@ -1,0 +1,90 @@
+package connectip
+
+import (
+	"errors"
+	"fmt"
+	"net/netip"
+	"slices"
+	"sync/atomic"
+)
+
+var (
+	rejectedIPv4Prefix = netip.PrefixFrom(netip.IPv4Unspecified(), 32)
+	rejectedIPv6Prefix = netip.PrefixFrom(netip.IPv6Unspecified(), 128)
+)
+
+// AddressRequestID identifies an address request. Zero denotes an unsolicited assignment.
+type AddressRequestID uint64
+
+// AddressRequest is a request received from the peer.
+// The zero value is not valid.
+type AddressRequest struct {
+	Prefixes []netip.Prefix
+
+	conn      *Conn
+	requested *addressRequestCapsule
+	// Use a pointer so copies of the request cannot be answered independently.
+	responded *atomic.Bool
+}
+
+func newAddressRequest(conn *Conn, requested *addressRequestCapsule) *AddressRequest {
+	return &AddressRequest{
+		Prefixes:  slices.Clone(requested.Prefixes),
+		conn:      conn,
+		requested: requested,
+		responded: &atomic.Bool{},
+	}
+}
+
+// Respond queues the complete address assignment for the peer.
+// Assignments must have one entry per original requested prefix, in the same order.
+// A zero-value netip.Prefix rejects that request.
+// Additional contains any other valid prefixes to include, with request ID zero.
+// All prefixes must have their host bits cleared.
+// A request can be answered only once.
+func (r *AddressRequest) Respond(assignments, additional []netip.Prefix) error {
+	if r.conn == nil {
+		return errors.New("connect-ip: invalid address request")
+	}
+	if len(assignments) != len(r.requested.RequestIDs) {
+		return fmt.Errorf(
+			"connect-ip: expected %d address assignments, got %d",
+			len(r.requested.RequestIDs),
+			len(assignments),
+		)
+	}
+	capsule := &addressAssignCapsule{
+		AssignedAddresses: make([]AssignedAddress, 0, len(assignments)+len(additional)),
+	}
+	var zeroPrefix netip.Prefix
+	for i, p := range assignments {
+		if p == zeroPrefix {
+			if r.requested.Prefixes[i].Addr().Is4() {
+				p = rejectedIPv4Prefix
+			} else {
+				p = rejectedIPv6Prefix
+			}
+		} else if !p.IsValid() || p != p.Masked() {
+			return fmt.Errorf("connect-ip: invalid assigned prefix %d: %s", i, p)
+		}
+		capsule.AssignedAddresses = append(
+			capsule.AssignedAddresses,
+			AssignedAddress{RequestID: r.requested.RequestIDs[i], IPPrefix: p},
+		)
+	}
+	for i, p := range additional {
+		if !p.IsValid() || p != p.Masked() {
+			return fmt.Errorf("connect-ip: invalid additional prefix %d: %s", i, p)
+		}
+		capsule.AssignedAddresses = append(capsule.AssignedAddresses, AssignedAddress{IPPrefix: p})
+	}
+	// claim the response after validation, so invalid inputs can be retried
+	if !r.responded.CompareAndSwap(false, true) {
+		return errors.New("connect-ip: address request already answered")
+	}
+	if err := r.conn.sendAddressAssignment(capsule); err != nil {
+		r.responded.Store(false)
+		return err
+	}
+	return nil
+}

--- a/address_test.go
+++ b/address_test.go
@@ -1,0 +1,79 @@
+package connectip
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddressRequests(t *testing.T) {
+	client, server := setupConns(t)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	prefixes := []netip.Prefix{
+		netip.MustParsePrefix("0.0.0.0/32"),
+		netip.MustParsePrefix("0.0.0.0/32"),
+		netip.MustParsePrefix("::/64"),
+	}
+	ids, err := client.RequestAddresses(prefixes)
+	require.NoError(t, err)
+	require.Equal(t, []AddressRequestID{1, 2, 3}, ids)
+	req, err := server.ReceiveAddressRequest(ctx)
+	require.NoError(t, err)
+	require.Equal(t, prefixes, req.Prefixes)
+
+	assignments := []netip.Prefix{netip.MustParsePrefix("192.0.2.1/32"), {}, {}}
+	additional := []netip.Prefix{netip.MustParsePrefix("2001:db8::/64")}
+	require.NoError(t, req.Respond(assignments, additional))
+	received, err := client.ReceiveAddressAssignment(ctx)
+	require.NoError(t, err)
+	require.Len(t, received, 4)
+	require.Equal(t, AssignedAddress{RequestID: ids[0], IPPrefix: assignments[0]}, received[0])
+	require.Equal(t, ids[1], received[1].RequestID)
+	require.True(t, received[1].Rejected())
+	require.Equal(t, ids[2], received[2].RequestID)
+	require.True(t, received[2].Rejected())
+	require.Equal(t, AssignedAddress{IPPrefix: additional[0]}, received[3])
+
+	ids, err = client.RequestAddresses(prefixes[:1])
+	require.NoError(t, err)
+	require.Equal(t, []AddressRequestID{4}, ids)
+}
+
+func TestAddressRequestValidation(t *testing.T) {
+	conn := newProxiedConn(&mockStream{}, nil)
+	defer conn.Close()
+
+	for _, prefixes := range [][]netip.Prefix{
+		nil,
+		{{}},
+		{netip.MustParsePrefix("192.0.2.1/24")},
+		{netip.MustParsePrefix("2001:db8::1/64")},
+	} {
+		ids, err := conn.RequestAddresses(prefixes)
+		require.Error(t, err)
+		require.Nil(t, ids)
+	}
+}
+
+func TestAddressResponseValidation(t *testing.T) {
+	conn := newProxiedConn(&mockStream{}, nil)
+	defer conn.Close()
+
+	prefixes := []netip.Prefix{netip.MustParsePrefix("192.0.2.1/32")}
+	req := newAddressRequest(conn, &addressRequestCapsule{RequestIDs: []AddressRequestID{1}, Prefixes: prefixes})
+	require.ErrorContains(t, (&AddressRequest{}).Respond(nil, nil), "invalid address request")
+	require.ErrorContains(t, req.Respond(nil, nil), "expected 1 address assignments")
+	require.ErrorContains(t, req.Respond(prefixes, []netip.Prefix{{}}), "invalid additional prefix")
+	require.ErrorContains(t,
+		req.Respond([]netip.Prefix{netip.MustParsePrefix("192.0.2.1/24")}, nil),
+		"invalid assigned prefix",
+	)
+
+	copied := *req
+	require.NoError(t, req.Respond(prefixes, nil))
+	require.ErrorContains(t, copied.Respond(prefixes, nil), "already answered")
+}

--- a/capsule.go
+++ b/capsule.go
@@ -37,27 +37,25 @@ type addressAssignCapsule struct {
 
 // AssignedAddress represents an Assigned Address within an ADDRESS_ASSIGN capsule
 type AssignedAddress struct {
-	RequestID uint64
+	// RequestID is zero for an unsolicited assignment.
+	RequestID AddressRequestID
 	IPPrefix  netip.Prefix
 }
 
+// Rejected reports whether the assignment is a refusal (0.0.0.0/32 or ::/128).
+func (a AssignedAddress) Rejected() bool {
+	return a.IPPrefix == rejectedIPv4Prefix || a.IPPrefix == rejectedIPv6Prefix
+}
+
 func (a AssignedAddress) len() int {
-	return quicvarint.Len(a.RequestID) + 1 + a.IPPrefix.Addr().BitLen()/8 + 1
+	return quicvarint.Len(uint64(a.RequestID)) + 1 + a.IPPrefix.Addr().BitLen()/8 + 1
 }
 
 // addressRequestCapsule represents an ADDRESS_REQUEST capsule
 type addressRequestCapsule struct {
-	RequestedAddresses []RequestedAddress
-}
-
-// RequestedAddress represents an Requested Address within an ADDRESS_REQUEST capsule
-type RequestedAddress struct {
-	RequestID uint64
-	IPPrefix  netip.Prefix
-}
-
-func (r RequestedAddress) len() int {
-	return quicvarint.Len(r.RequestID) + 1 + r.IPPrefix.Addr().BitLen()/8 + 1
+	// RequestIDs and Prefixes have matching lengths and order.
+	RequestIDs []AddressRequestID
+	Prefixes   []netip.Prefix
 }
 
 func parseAddressAssignCapsule(r http3.CapsuleReader) (*addressAssignCapsule, error) {
@@ -70,7 +68,7 @@ func parseAddressAssignCapsule(r http3.CapsuleReader) (*addressAssignCapsule, er
 		if err != nil {
 			return nil, err
 		}
-		assignedAddresses = append(assignedAddresses, AssignedAddress{RequestID: requestID, IPPrefix: prefix})
+		assignedAddresses = append(assignedAddresses, AssignedAddress{RequestID: AddressRequestID(requestID), IPPrefix: prefix})
 	}
 	return &addressAssignCapsule{AssignedAddresses: assignedAddresses}, nil
 }
@@ -85,7 +83,7 @@ func (c *addressAssignCapsule) append(b []byte) []byte {
 	b = quicvarint.Append(b, uint64(totalLen))
 
 	for _, addr := range c.AssignedAddresses {
-		b = quicvarint.Append(b, addr.RequestID)
+		b = quicvarint.Append(b, uint64(addr.RequestID))
 		if addr.IPPrefix.Addr().Is4() {
 			b = append(b, 4)
 		} else {
@@ -98,38 +96,45 @@ func (c *addressAssignCapsule) append(b []byte) []byte {
 }
 
 func parseAddressRequestCapsule(r http3.CapsuleReader) (*addressRequestCapsule, error) {
-	var requestedAddresses []RequestedAddress
+	if r.Remaining() == 0 {
+		return nil, errors.New("ADDRESS_REQUEST capsule contains no addresses")
+	}
+	capsule := &addressRequestCapsule{}
 	for r.Remaining() > 0 {
-		if len(requestedAddresses) >= maxAddressesPerCapsule {
+		if len(capsule.Prefixes) >= maxAddressesPerCapsule {
 			return nil, fmt.Errorf("ADDRESS_REQUEST capsule contains too many addresses (maximum %d)", maxAddressesPerCapsule)
 		}
 		requestID, prefix, err := parseAddress(r)
 		if err != nil {
 			return nil, err
 		}
-		requestedAddresses = append(requestedAddresses, RequestedAddress{RequestID: requestID, IPPrefix: prefix})
+		if requestID == 0 {
+			return nil, errors.New("ADDRESS_REQUEST capsule contains a zero request ID")
+		}
+		capsule.RequestIDs = append(capsule.RequestIDs, AddressRequestID(requestID))
+		capsule.Prefixes = append(capsule.Prefixes, prefix)
 	}
-	return &addressRequestCapsule{RequestedAddresses: requestedAddresses}, nil
+	return capsule, nil
 }
 
 func (c *addressRequestCapsule) append(b []byte) []byte {
 	var totalLen int
-	for _, addr := range c.RequestedAddresses {
-		totalLen += addr.len()
+	for i, p := range c.Prefixes {
+		totalLen += quicvarint.Len(uint64(c.RequestIDs[i])) + 1 + p.Addr().BitLen()/8 + 1
 	}
 
 	b = quicvarint.Append(b, uint64(capsuleTypeAddressRequest))
 	b = quicvarint.Append(b, uint64(totalLen))
 
-	for _, addr := range c.RequestedAddresses {
-		b = quicvarint.Append(b, addr.RequestID)
-		if addr.IPPrefix.Addr().Is4() {
+	for i, p := range c.Prefixes {
+		b = quicvarint.Append(b, uint64(c.RequestIDs[i]))
+		if p.Addr().Is4() {
 			b = append(b, 4)
 		} else {
 			b = append(b, 6)
 		}
-		b = append(b, addr.IPPrefix.Addr().AsSlice()...)
-		b = append(b, byte(addr.IPPrefix.Bits()))
+		b = append(b, p.Addr().AsSlice()...)
+		b = append(b, byte(p.Bits()))
 	}
 	return b
 }

--- a/capsule_test.go
+++ b/capsule_test.go
@@ -102,6 +102,16 @@ func TestParseAddressAssignCapsuleLimit(t *testing.T) {
 	testCapsuleEntryLimit(t, capsuleTypeAddressAssign, maxAddressesPerCapsule, entry, parseAddressAssignCapsule)
 }
 
+func TestAssignedAddressRejected(t *testing.T) {
+	for _, prefix := range []string{"0.0.0.0/32", "::/128"} {
+		require.True(t, (AssignedAddress{RequestID: 1, IPPrefix: netip.MustParsePrefix(prefix)}).Rejected())
+	}
+	for _, prefix := range []string{"0.0.0.0/0", "0.0.0.0/31", "::/0", "::/127", "192.0.2.1/32", "2001:db8::1/128"} {
+		require.False(t, (AssignedAddress{RequestID: 1, IPPrefix: netip.MustParsePrefix(prefix)}).Rejected())
+	}
+	require.False(t, (AssignedAddress{}).Rejected())
+}
+
 func TestWriteAddressAssignCapsule(t *testing.T) {
 	c := &addressAssignCapsule{
 		AssignedAddresses: []AssignedAddress{
@@ -164,10 +174,8 @@ func testParseAddressCapsuleInvalid(t *testing.T, typ http3.CapsuleType, f func(
 			}).append(nil)
 		case capsuleTypeAddressRequest:
 			data = (&addressRequestCapsule{
-				RequestedAddresses: []RequestedAddress{
-					{RequestID: 1337, IPPrefix: netip.MustParsePrefix("1.2.3.4/32")},
-					{RequestID: 1338, IPPrefix: netip.MustParsePrefix("2001:db8::1/128")},
-				},
+				RequestIDs: []AddressRequestID{1337, 1338},
+				Prefixes:   []netip.Prefix{netip.MustParsePrefix("1.2.3.4/32"), netip.MustParsePrefix("2001:db8::1/128")},
 			}).append(nil)
 		default:
 			t.Fatalf("unexpected capsule type: %d", typ)
@@ -197,13 +205,8 @@ func TestParseAddressRequestCapsule(t *testing.T) {
 	require.Equal(t, capsuleTypeAddressRequest, typ)
 	capsule, err := parseAddressRequestCapsule(cr)
 	require.NoError(t, err)
-	require.Equal(t,
-		[]RequestedAddress{
-			{RequestID: 1337, IPPrefix: netip.MustParsePrefix("1.2.3.0/24")},
-			{RequestID: 1338, IPPrefix: netip.MustParsePrefix("2001:db8::1/128")},
-		},
-		capsule.RequestedAddresses,
-	)
+	require.Equal(t, []AddressRequestID{1337, 1338}, capsule.RequestIDs)
+	require.Equal(t, []netip.Prefix{netip.MustParsePrefix("1.2.3.0/24"), netip.MustParsePrefix("2001:db8::1/128")}, capsule.Prefixes)
 	require.Zero(t, r.Len())
 }
 
@@ -214,10 +217,8 @@ func TestParseAddressRequestCapsuleLimit(t *testing.T) {
 
 func TestWriteAddressRequestCapsule(t *testing.T) {
 	c := &addressRequestCapsule{
-		RequestedAddresses: []RequestedAddress{
-			{RequestID: 1337, IPPrefix: netip.MustParsePrefix("1.2.3.0/24")},
-			{RequestID: 1338, IPPrefix: netip.MustParsePrefix("2001:db8::1/128")},
-		},
+		RequestIDs: []AddressRequestID{1337, 1338},
+		Prefixes:   []netip.Prefix{netip.MustParsePrefix("1.2.3.0/24"), netip.MustParsePrefix("2001:db8::1/128")},
 	}
 	data := c.append(nil)
 	r := bytes.NewReader(data)
@@ -231,6 +232,14 @@ func TestWriteAddressRequestCapsule(t *testing.T) {
 }
 
 func TestParseAddressRequestCapsuleInvalid(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		_, err := parseAddressRequestCapsule(newCapsuleReader(t, capsuleTypeAddressRequest, nil))
+		require.ErrorContains(t, err, "contains no addresses")
+	})
+	t.Run("zero request ID", func(t *testing.T) {
+		_, err := parseAddressRequestCapsule(newCapsuleReader(t, capsuleTypeAddressRequest, []byte{0, 4, 192, 0, 2, 1, 32}))
+		require.ErrorContains(t, err, "zero request ID")
+	})
 	testParseAddressCapsuleInvalid(t, capsuleTypeAddressRequest, func(r http3.CapsuleReader) error {
 		_, err := parseAddressRequestCapsule(r)
 		return err

--- a/conn.go
+++ b/conn.go
@@ -52,8 +52,8 @@ var (
 // On IPv6, the minimum MTU of a link is 1280 bytes.
 const minMTU = 1280
 
-// Capsules normally don't remain queued: they are written to the CONNECT stream
-// immediately. The queue only grows if the peer falls behind processing the stream.
+// Bound pending capsules in both directions. Queues only grow when the peer
+// falls behind reading the stream or the application falls behind receiving updates.
 const maxQueuedCapsules = 128
 
 type streamWrite struct {
@@ -68,16 +68,18 @@ type Conn struct {
 	writeNotify chan struct{}
 	writeDone   chan error
 
-	assignedAddressUpdates  chan []netip.Prefix
+	assignedAddressUpdates  chan []AssignedAddress
+	addressRequests         chan *addressRequestCapsule
 	availableRouteUpdates   chan []IPRoute
 	dnsConfigurationUpdates chan []DNSConfiguration
 	pref64Updates           chan []netip.Prefix
 
-	mu                sync.Mutex
-	queuedWrites      []streamWrite
-	peerAddresses     []netip.Prefix // IP prefixes that we assigned to the peer
-	localRoutes       []IPRoute      // IP routes that we advertised to the peer
-	assignedAddresses []netip.Prefix
+	mu                   sync.Mutex
+	queuedWrites         []streamWrite
+	peerAddresses        []netip.Prefix // IP prefixes that we assigned to the peer
+	localRoutes          []IPRoute      // IP routes that we advertised to the peer
+	assignedAddresses    []netip.Prefix
+	lastAddressRequestID AddressRequestID
 
 	closeChan chan struct{}
 	closeErr  error
@@ -89,7 +91,8 @@ func newProxiedConn(str http3Stream, closeConn func() error) *Conn {
 		closeConn:               closeConn,
 		writeNotify:             make(chan struct{}, 1),
 		writeDone:               make(chan error, 1),
-		assignedAddressUpdates:  make(chan []netip.Prefix, 1),
+		assignedAddressUpdates:  make(chan []AssignedAddress, maxQueuedCapsules),
+		addressRequests:         make(chan *addressRequestCapsule, maxQueuedCapsules),
 		availableRouteUpdates:   make(chan []IPRoute, 1),
 		dnsConfigurationUpdates: make(chan []DNSConfiguration, 1),
 		pref64Updates:           make(chan []netip.Prefix, 1),
@@ -165,35 +168,127 @@ func (c *Conn) AdvertiseRoute(routes []IPRoute) error {
 	return nil
 }
 
-// AssignAddresses schedules an assignment of address prefixes to the peer.
-// It returns once the assignment has been queued.
-func (c *Conn) AssignAddresses(prefixes []netip.Prefix) error {
-	capsule := &addressAssignCapsule{AssignedAddresses: make([]AssignedAddress, 0, len(prefixes))}
-	for _, p := range prefixes {
-		capsule.AssignedAddresses = append(capsule.AssignedAddresses, AssignedAddress{IPPrefix: p})
+// RequestAddresses requests address prefixes from the peer and returns once the
+// request is queued. It allocates a unique, nonzero ID for each prefix in input order.
+// The IDs have no semantic meaning and can be used to correlate assignments
+// returned by [Conn.ReceiveAddressAssignment] with the requested prefixes.
+//
+// Prefixes must be valid, with all bits outside the prefix set to zero.
+// An unspecified address (0.0.0.0 or ::) requests any address of that family,
+// with the prefix length indicating the preferred size.
+func (c *Conn) RequestAddresses(prefixes []netip.Prefix) ([]AddressRequestID, error) {
+	if len(prefixes) == 0 {
+		return nil, errors.New("connect-ip: address request must contain at least one prefix")
+	}
+	for i, p := range prefixes {
+		if !p.IsValid() || p != p.Masked() {
+			return nil, fmt.Errorf("connect-ip: invalid requested prefix %d: %s", i, p)
+		}
 	}
 
 	c.mu.Lock()
 	if c.closeErr != nil {
 		err := c.closeErr
 		c.mu.Unlock()
-		return err
+		return nil, err
 	}
+	ids := make([]AddressRequestID, len(prefixes))
+	for i := range ids {
+		ids[i] = c.lastAddressRequestID + AddressRequestID(i) + 1
+	}
+	capsule := &addressRequestCapsule{RequestIDs: ids, Prefixes: prefixes}
 	err := c.queueWrite(streamWrite{Data: capsule.append(nil)})
 	if err == nil {
-		c.peerAddresses = slices.Clone(prefixes)
+		c.lastAddressRequestID = ids[len(ids)-1]
 	}
 	c.mu.Unlock()
 	if err != nil {
 		_ = c.Close()
+		return nil, err
+	}
+	return ids, nil
+}
+
+// ReceiveAddressAssignment waits for the next complete address assignment,
+// Each assignment replaces the preceding one; request IDs only provide optional correlation.
+// Call this method in a loop from one goroutine.
+func (c *Conn) ReceiveAddressAssignment(ctx context.Context) ([]AssignedAddress, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case assignment := <-c.assignedAddressUpdates:
+		return assignment, nil
+	case <-c.closeChan:
+		// Deliver queued responses before reporting closure.
+		select {
+		case assignment := <-c.assignedAddressUpdates:
+			return assignment, nil
+		default:
+			return nil, c.closeErr
+		}
+	}
+}
+
+// ReceiveAddressRequest waits for the next address request from the peer.
+// This method should be called in a loop, and each request should be answered with [AddressRequest.Respond].
+func (c *Conn) ReceiveAddressRequest(ctx context.Context) (*AddressRequest, error) {
+	var requested *addressRequestCapsule
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case requested = <-c.addressRequests:
+	case <-c.closeChan:
+		select {
+		case requested = <-c.addressRequests:
+		default:
+			return nil, c.closeErr
+		}
+	}
+	return newAddressRequest(c, requested), nil
+}
+
+// AssignAddresses schedules an assignment of address prefixes to the peer.
+func (c *Conn) AssignAddresses(prefixes []netip.Prefix) error {
+	capsule := &addressAssignCapsule{}
+	if prefixes != nil {
+		capsule.AssignedAddresses = make([]AssignedAddress, len(prefixes))
+		for i, p := range prefixes {
+			capsule.AssignedAddresses[i] = AssignedAddress{IPPrefix: p}
+		}
+	}
+	return c.sendAddressAssignment(capsule)
+}
+
+func (c *Conn) sendAddressAssignment(capsule *addressAssignCapsule) error {
+	c.mu.Lock()
+	if c.closeErr != nil {
+		err := c.closeErr
+		c.mu.Unlock()
 		return err
 	}
+	if err := c.queueWrite(streamWrite{Data: capsule.append(nil)}); err != nil {
+		c.mu.Unlock()
+		_ = c.Close()
+		return err
+	}
+
+	var prefixes []netip.Prefix
+	// Preserve nil (no source restriction) versus an empty assignment.
+	if capsule.AssignedAddresses != nil {
+		prefixes = make([]netip.Prefix, 0, len(capsule.AssignedAddresses))
+	}
+	for _, assigned := range capsule.AssignedAddresses {
+		if !assigned.Rejected() {
+			prefixes = append(prefixes, assigned.IPPrefix)
+		}
+	}
+	c.peerAddresses = prefixes
+	c.mu.Unlock()
 	return nil
 }
 
 // SendDNSConfiguration schedules a DNS configuration update to the peer.
-// It returns once the update has been queued. The update supersedes the DNS
-// configuration previously sent on this connection.
+// The update supersedes the DNS configuration previously sent on this connection.
 //
 // To avoid leaking DNS traffic outside the tunnel, the application is responsible
 // for advertising the corresponding routes before calling this method. See
@@ -300,22 +395,6 @@ func queueLatest[T any](ch chan T, value T) {
 	}
 }
 
-// LocalPrefixes returns the prefixes that the peer currently assigned.
-// Note that at any point during the connection, the peer can change the assignment.
-// It is therefore recommended to call this function in a loop.
-func (c *Conn) LocalPrefixes(ctx context.Context) ([]netip.Prefix, error) {
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-c.closeChan:
-		return nil, c.closeErr
-	case prefixes := <-c.assignedAddressUpdates:
-		// Callers are expected to treat returned prefixes as immutable.
-		// Clone them defensively so accidental mutation cannot change connection state.
-		return slices.Clone(prefixes), nil
-	}
-}
-
 // Routes returns the routes that the peer currently advertised.
 // Note that at any point during the connection, the peer can change the advertised routes.
 // It is therefore recommended to call this function in a loop.
@@ -348,17 +427,28 @@ func (c *Conn) readFromStream() error {
 			}
 			prefixes := make([]netip.Prefix, 0, len(capsule.AssignedAddresses))
 			for _, assigned := range capsule.AssignedAddresses {
-				prefixes = append(prefixes, assigned.IPPrefix)
+				if !assigned.Rejected() {
+					prefixes = append(prefixes, assigned.IPPrefix)
+				}
 			}
 			c.mu.Lock()
 			c.assignedAddresses = prefixes
 			c.mu.Unlock()
-			queueLatest(c.assignedAddressUpdates, prefixes)
+			select {
+			case c.assignedAddressUpdates <- capsule.AssignedAddresses:
+			default:
+				return errors.New("connect-ip: address assignment queue full")
+			}
 		case capsuleTypeAddressRequest:
-			if _, err := parseAddressRequestCapsule(cr); err != nil {
+			capsule, err := parseAddressRequestCapsule(cr)
+			if err != nil {
 				return err
 			}
-			return errors.New("connect-ip: address request not yet supported")
+			select {
+			case c.addressRequests <- capsule:
+			default:
+				return errors.New("connect-ip: address request queue full")
+			}
 		case capsuleTypeRouteAdvertisement:
 			capsule, err := parseRouteAdvertisementCapsule(cr)
 			if err != nil {

--- a/conn_test.go
+++ b/conn_test.go
@@ -68,7 +68,7 @@ func (m *mockStream) ReceiveDatagram(ctx context.Context) ([]byte, error) {
 	return nil, ctx.Err()
 }
 
-func TestCapsuleQueueLimit(t *testing.T) {
+func TestCapsuleWriteQueueLimit(t *testing.T) {
 	writes := make(chan []byte)
 	writeStarted := make(chan struct{})
 	conn := newProxiedConn(&mockStream{
@@ -95,6 +95,30 @@ func TestCapsuleQueueLimit(t *testing.T) {
 	}()
 	require.ErrorContains(t, conn.AssignAddresses(nil), "capsule queue full")
 	require.ErrorIs(t, conn.AssignAddresses(nil), net.ErrClosed)
+}
+
+func TestCapsuleReceiveQueueLimit(t *testing.T) {
+	for _, name := range []string{"assignments", "requests"} {
+		t.Run(name, func(t *testing.T) {
+			var data []byte
+			for i := range maxQueuedCapsules + 1 {
+				if name == "assignments" {
+					data = (&addressAssignCapsule{}).append(data)
+				} else {
+					data = (&addressRequestCapsule{
+						RequestIDs: []AddressRequestID{AddressRequestID(i + 1)},
+						Prefixes:   []netip.Prefix{netip.MustParsePrefix("192.0.2.1/32")},
+					}).append(data)
+				}
+			}
+			conn := newProxiedConn(&mockStream{reading: data}, nil)
+			t.Cleanup(func() { conn.Close() })
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			_, err := conn.Routes(ctx)
+			require.ErrorIs(t, err, net.ErrClosed)
+		})
+	}
 }
 
 func TestDNSConfiguration(t *testing.T) {
@@ -392,7 +416,7 @@ func TestIncomingDatagrams(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
-		_, err = conn.LocalPrefixes(ctx)
+		_, err = conn.ReceiveAddressAssignment(ctx)
 		require.NoError(t, err)
 		// after processing the address assignment, this is a valid packet
 		require.NoError(t, conn.handleIncomingProxiedPacket(data))
@@ -413,9 +437,9 @@ func TestSkipUnknownCapsule(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	prefixes, err := conn.LocalPrefixes(ctx)
+	assigned, err := conn.ReceiveAddressAssignment(ctx)
 	require.NoError(t, err)
-	require.Equal(t, []netip.Prefix{netip.MustParsePrefix("192.168.0.10/32")}, prefixes)
+	require.Equal(t, []AssignedAddress{{IPPrefix: netip.MustParsePrefix("192.168.0.10/32")}}, assigned)
 }
 
 func FuzzIncomingDatagram(f *testing.F) {

--- a/integration/client/client.go
+++ b/integration/client/client.go
@@ -151,7 +151,7 @@ func establishConn(proxyAddr netip.AddrPort, keyLog io.Writer) (*water.Interface
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get routes: %w", err)
 	}
-	localPrefixes, err := ipconn.LocalPrefixes(ctx)
+	assigned, err := ipconn.ReceiveAddressAssignment(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get local prefixes: %w", err)
 	}
@@ -166,7 +166,11 @@ func establishConn(proxyAddr netip.AddrPort, keyLog io.Writer) (*water.Interface
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get TUN interface: %w", err)
 	}
-	for _, p := range localPrefixes {
+	for _, a := range assigned {
+		if a.Rejected() {
+			continue
+		}
+		p := a.IPPrefix
 		if err := netlink.AddrAdd(link, &netlink.Addr{IPNet: utils.PrefixToIPNet(p)}); err != nil {
 			return nil, nil, fmt.Errorf("failed to add address assigned by peer %s: %w", p, err)
 		}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -73,7 +73,7 @@ func TestAddressAssignment(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
-	_, err := server.Routes(ctx)
+	_, err := server.ReceiveAddressAssignment(ctx)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
@@ -81,15 +81,15 @@ func TestAddressAssignment(t *testing.T) {
 	pref1 := netip.MustParsePrefix("1.1.1.0/24")
 	pref2 := netip.MustParsePrefix("2001:db8::/64")
 	require.NoError(t, client.AssignAddresses([]netip.Prefix{pref1, pref2}))
-	routes, err := server.LocalPrefixes(ctx)
+	assigned, err := server.ReceiveAddressAssignment(ctx)
 	require.NoError(t, err)
-	require.Equal(t, []netip.Prefix{pref1, pref2}, routes)
+	require.Equal(t, []AssignedAddress{{IPPrefix: pref1}, {IPPrefix: pref2}}, assigned)
 
 	// addresses are replaced once a new capsule is received
 	require.NoError(t, client.AssignAddresses([]netip.Prefix{}))
-	routes, err = server.LocalPrefixes(ctx)
+	assigned, err = server.ReceiveAddressAssignment(ctx)
 	require.NoError(t, err)
-	require.Empty(t, routes)
+	require.Empty(t, assigned)
 }
 
 func TestRouteAdvertisement(t *testing.T) {
@@ -239,12 +239,12 @@ func TestClosing(t *testing.T) {
 		routeErrChan <- err
 	}()
 	go func() {
-		_, err := server.LocalPrefixes(context.Background())
+		_, err := server.ReceiveAddressAssignment(context.Background())
 		prefixErrChan <- err
 	}()
 
 	require.NoError(t, client.Close())
-	_, err := client.LocalPrefixes(context.Background())
+	_, err := client.ReceiveAddressAssignment(context.Background())
 	require.ErrorIs(t, err, net.ErrClosed)
 	var closeErr *CloseError
 	require.ErrorAs(t, err, &closeErr)


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add `AddressRequest` send/receive support and replace `LocalPrefixes` with `ReceiveAddressAssignment`
- Adds `connectip.RequestAddresses`, `ReceiveAddressRequest`, and `AddressRequest.Respond` so applications can request prefixes from peers, receive peer address requests, and reply with assignments or canonical refusal prefixes
- Replaces `LocalPrefixes` with `ReceiveAddressAssignment`, which returns full `AssignedAddress` records carrying request IDs and rejection markers instead of bare prefixes
- Refactors the internal capsule model to parallel `RequestIDs` and `Prefixes` slices; `parseAddressRequestCapsule` now rejects empty capsules and zero request IDs
- Assignment and request updates flow through bounded channels (`maxQueuedCapsules`); stream reader fails the connection when either inbound queue saturates
- Behavioral Change: `LocalPrefixes` is removed; all in-tree callers in [conn.go](https://github.com/quic-go/connect-ip-go/pull/89/files#diff-4f427d2b022907c552328e63f137561f6de92396d7a6e8f6c2ea1bcf0db52654), [proxy_test.go](https://github.com/quic-go/connect-ip-go/pull/89/files#diff-1ad863f10fb8c2c1ed4cbd0c2316a75ece3f5c78458506ca8c95b5f03533236a), and [integration/client/client.go](https://github.com/quic-go/connect-ip-go/pull/89/files#diff-e4dcb74a25209a40eb9e303588ac319a427316a6c510246eb069a1537628b379) are migrated to `ReceiveAddressAssignment`. `AssignedAddress.RequestID` type changes from raw `uint` to `AddressRequestID`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6f01fa6.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for requesting and receiving peer-assigned IP addresses.
  - Requests can include multiple prefixes, additional assignments, and explicit IPv4/IPv6 rejections.
  - Added request identifiers and assignment status reporting.
  - Clients now automatically apply accepted assigned addresses while skipping rejected assignments.

- **API Changes**
  - Address assignments are now received through the new assignment-receiving interface.
  - Replaced the previous local-prefix retrieval method with assignment-aware results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->